### PR TITLE
feat: enhance item detail layout

### DIFF
--- a/src/pages/ItemDetailPage.vue
+++ b/src/pages/ItemDetailPage.vue
@@ -17,7 +17,9 @@
     <div v-else class="pk-reveal" data-anim="animate__fadeInUp">
       <div class="text-center mb-4">
         <h1 class="fw-bold mb-1">{{ itemData?.name }}</h1>
-        <small class="d-block text-muted">{{ itemData.event.vendor.displayName }}</small>
+        <small class="d-block text-muted">
+          {{ itemData.event.vendor.displayName }} @ {{ itemData.event.displayName }}
+        </small>
         <small v-if="itemData?.price" class="d-block text-info">{{ itemData.price }}</small>
       </div>
 
@@ -47,25 +49,31 @@
         </ol>
       </nav>
 
-      <div class="card bg-dark border-0 text-light mb-4 shadow-sm">
+      <div class="card bg-light border-0 mb-4 shadow-sm">
         <div class="card-body">
           <h2 class="h5 mb-3 text-primary"><i class="bi bi-fork-knife me-2"></i>About the delight!</h2>
           <p class="mb-3">{{ itemData?.description }}</p>
           <div v-if="itemData?.ingredients" class="d-flex flex-wrap gap-2">
-            <span v-for="ing in itemData.ingredients.split(',')" :key="ing" class="badge bg-secondary">{{ ing.trim() }}</span>
+            <span
+              v-for="ing in itemData.ingredients.split(',')"
+              :key="ing"
+              class="badge bg-light text-dark border"
+            >
+              {{ ing.trim() }}
+            </span>
           </div>
         </div>
       </div>
 
       <div class="my-4">
         <div class="d-flex justify-content-center gap-3 mb-3">
-          <button type="button" class="btn btn-outline-success btn-lg d-flex align-items-center gap-2">
-            <i class="bi bi-hand-thumbs-up-fill"></i>
+          <button type="button" class="btn btn-outline-primary d-flex align-items-center gap-2 px-3 py-1">
+            <i class="bi bi-hand-thumbs-up"></i>
             <span>{{ itemData?.likes ?? 0 }}</span>
             <span class="visually-hidden">Like</span>
           </button>
-          <button type="button" class="btn btn-outline-danger btn-lg d-flex align-items-center gap-2">
-            <i class="bi bi-hand-thumbs-down-fill"></i>
+          <button type="button" class="btn btn-outline-secondary d-flex align-items-center gap-2 px-3 py-1">
+            <i class="bi bi-hand-thumbs-down"></i>
             <span>{{ itemData?.dislikes ?? 0 }}</span>
             <span class="visually-hidden">Dislike</span>
           </button>
@@ -90,17 +98,6 @@
           <i class="bi bi-share-fill me-1"></i>Share
         </button>
       </div>
-    </div>
-  </div>
-
-  <div class="d-md-none fixed-bottom bg-dark py-2 border-top">
-    <div class="container d-flex justify-content-between">
-      <button class="btn btn-link text-decoration-none text-light" @click="win.history.back()">
-        <i class="bi bi-arrow-left-circle me-1"></i>Back to Menu
-      </button>
-      <button class="btn btn-link text-decoration-none text-light" @click="win.navigator?.share && win.navigator?.share({ title: itemData?.name, url: win.location.href })">
-        <i class="bi bi-share-fill me-1"></i>Share
-      </button>
     </div>
   </div>
 </template>

--- a/src/pages/ItemDetailPage.vue
+++ b/src/pages/ItemDetailPage.vue
@@ -53,43 +53,37 @@
         <div class="card-body">
           <h2 class="h5 mb-3 text-primary"><i class="bi bi-fork-knife me-2"></i>About the delight!</h2>
           <p class="mb-3">{{ itemData?.description }}</p>
-          <div v-if="itemData?.ingredients" class="d-flex flex-wrap gap-2">
+          <div v-if="itemData?.ingredients" class="d-flex flex-wrap gap-2 mb-3">
             <span
               v-for="ing in itemData.ingredients.split(',')"
               :key="ing"
-              class="badge bg-light text-dark border"
+              class="badge bg-secondary pk-beige-text"
             >
               {{ ing.trim() }}
+            </span>
+          </div>
+          <div v-if="itemData?.allergens?.length" class="d-flex flex-wrap gap-2">
+            <span
+              v-for="allergen in itemData.allergens"
+              :key="allergen"
+              class="badge bg-danger"
+            >
+              {{ allergen }}
             </span>
           </div>
         </div>
       </div>
 
-      <div class="my-4">
-        <div class="d-flex justify-content-center gap-3 mb-3">
-          <button type="button" class="btn btn-outline-primary d-flex align-items-center gap-2 px-3 py-1">
-            <i class="bi bi-hand-thumbs-up"></i>
-            <span>{{ itemData?.likes ?? 0 }}</span>
-            <span class="visually-hidden">Like</span>
-          </button>
-          <button type="button" class="btn btn-outline-secondary d-flex align-items-center gap-2 px-3 py-1">
-            <i class="bi bi-hand-thumbs-down"></i>
-            <span>{{ itemData?.dislikes ?? 0 }}</span>
-            <span class="visually-hidden">Dislike</span>
-          </button>
-        </div>
-
-        <div class="d-flex flex-column align-items-center">
-          <span class="mb-2">Rate this item</span>
-          <div class="d-flex">
-            <template v-for="n in 5">
-              <input :id="'rate'+n" type="radio" class="btn-check" name="rating">
-              <label :for="'rate'+n" class="btn btn-sm btn-outline-warning me-1">
-                <i class="bi bi-star-fill"></i>
-                <span class="visually-hidden">{{ n }} star</span>
-              </label>
-            </template>
-          </div>
+      <div class="my-4 d-flex flex-column align-items-center">
+        <span class="mb-2">Rate this item</span>
+        <div class="d-flex">
+          <template v-for="n in 5">
+            <input :id="'rate'+n" type="radio" class="btn-check" name="rating">
+            <label :for="'rate'+n" class="btn btn-sm btn-outline-primary me-1">
+              <i class="bi bi-star-fill"></i>
+              <span class="visually-hidden">{{ n }} star</span>
+            </label>
+          </template>
         </div>
       </div>
 
@@ -152,5 +146,6 @@ onMounted(async () => {
 .pk-reveal { opacity: 0; }
 .pk-visible { opacity: 1; }
 .pk-hero-img { object-fit: cover; }
+.pk-beige-text { color: beige; }
 </style>
 

--- a/src/pages/ItemDetailPage.vue
+++ b/src/pages/ItemDetailPage.vue
@@ -57,7 +57,7 @@
             <span
               v-for="ing in itemData.ingredients.split(',')"
               :key="ing"
-              class="badge bg-secondary pk-beige-text"
+              class="badge bg-info pk-beige-text"
             >
               {{ ing.trim() }}
             </span>

--- a/src/pages/ItemDetailPage.vue
+++ b/src/pages/ItemDetailPage.vue
@@ -1,71 +1,112 @@
 <template>
-  <Navbar></Navbar>
+  <Navbar />
 
-
-
-  <div class="container-fluid text-center">
-
-    
-
-    <div v-if="isLoading">
-      <div class="spinner-grow text-primary justify-content-center shadow-lg" style="margin-top:15%; width: 3rem; height: 3rem;" role="status">
-  <span class="visually-hidden">Loading...</span>
-</div>
-<br>
-<div class="spinner-grow text-info justify-content-center shadow-lg" style="margin-top:15%; width: 2rem; height: 2rem;" role="status">
-  <span class="visually-hidden">Loading...</span>
-
-  
-</div>
-<br>
-<div class="spinner-grow text-white justify-content-center shadow-lg" style="margin-top:15%; width: 1rem; height: 1rem;" role="status">
-  <span class="visually-hidden">Loading...</span>
-
-  
-</div>
-<br>
-<div class="spinner-grow text-primary justify-content-center shadow-lg" style="margin-top:15%; width: 3rem; height: 3rem;" role="status">
-  <span class="visually-hidden">Loading...</span>
-</div>
-    </div>
-    <div v-else-if="error">{{ error }}</div>
-    <div v-else>
-      <div class="row alert bg-white text-primary shadow-sm justify-content-center">
-         {{itemData.event.vendor.displayName}} 
-        @ {{itemData.event.displayName}}
+  <div class="container py-3">
+    <div v-if="isLoading" class="text-center py-5">
+      <div class="spinner-grow text-primary shadow-lg" style="width: 3rem; height: 3rem;" role="status">
+        <span class="visually-hidden">Loading...</span>
       </div>
-      <nav aria-label="breadcrumb">
-  <ul class="breadcrumb">
-    
-    <li v-for="parentItem in itemData.parentItems" class="breadcrumb-item">{{ parentItem.displayName }}</li>
-  </ul>
-</nav>
-      <hr>
-      <h1 class="text-secondary">{{ itemData?.name }}</h1>
-        
-        <img v-bind:src="itemData?.image" style="max-width:100%" alt="dish"> 
-        <hr width="50%" class="mx-auto text-primary mt-0">
-    
+      <div class="spinner-grow text-info shadow-lg mt-3" style="width: 2rem; height: 2rem;" role="status">
+        <span class="visually-hidden">Loading...</span>
+      </div>
+      <div class="spinner-grow text-white shadow-lg mt-3" style="width: 1rem; height: 1rem;" role="status">
+        <span class="visually-hidden">Loading...</span>
+      </div>
+    </div>
+    <div v-else-if="error" class="text-danger">{{ error }}</div>
+    <div v-else class="pk-reveal" data-anim="animate__fadeInUp">
+      <div class="text-center mb-4">
+        <h1 class="fw-bold mb-1">{{ itemData?.name }}</h1>
+        <small class="d-block text-muted">{{ itemData.event.vendor.displayName }}</small>
+        <small v-if="itemData?.price" class="d-block text-info">{{ itemData.price }}</small>
+      </div>
 
-    <h3 class="text-primary text-center"><i class="bi bi-fork-knife"></i> About the delight!</h3>
-  <h6>
-  {{itemData?.description}}
-  </h6>
-  <br>
-  <h6 class="text-info"><i class="bi bi-info-circle-fill"></i> Ingredients: </h6>
-  <h6>
-  <em>{{itemData?.ingredients}}</em>
-  </h6>
-</div>
+      <div class="d-flex justify-content-center mb-3">
+        <div class="col-12 col-md-10 col-lg-8">
+          <div class="ratio ratio-16x9">
+            <img :src="itemData?.image" :alt="itemData?.name" class="w-100 h-100 rounded shadow pk-hero-img" loading="lazy" />
+          </div>
+        </div>
+      </div>
+
+      <div class="d-flex flex-wrap justify-content-center gap-2 mb-4">
+        <span v-if="itemData?.isVeg !== undefined" class="badge bg-light text-dark d-flex align-items-center">
+          <i :class="['bi','bi-circle-fill', itemData.isVeg ? 'text-success' : 'text-danger']"></i>
+          <span class="ms-1">{{ itemData.isVeg ? 'Veg' : 'Non-Veg' }}</span>
+        </span>
+        <span v-for="tag in itemData?.tags || []" :key="tag" class="badge bg-info text-dark">{{ tag }}</span>
+        <span v-for="allergen in itemData?.allergens || []" :key="allergen" class="badge bg-warning text-dark">{{ allergen }}</span>
+        <span v-if="itemData?.spiceLevel" class="badge bg-light text-danger">
+          <i v-for="n in 3" :key="n" class="bi bi-fire" :class="{'opacity-25': n > itemData.spiceLevel}"></i>
+        </span>
+      </div>
+
+      <nav v-if="itemData.parentItems?.length" class="mb-3" aria-label="breadcrumb">
+        <ol class="breadcrumb justify-content-center mb-0">
+          <li v-for="parentItem in itemData.parentItems" :key="parentItem.displayName" class="breadcrumb-item">{{ parentItem.displayName }}</li>
+        </ol>
+      </nav>
+
+      <div class="card bg-dark border-0 text-light mb-4 shadow-sm">
+        <div class="card-body">
+          <h2 class="h5 mb-3 text-primary"><i class="bi bi-fork-knife me-2"></i>About the delight!</h2>
+          <p class="mb-3">{{ itemData?.description }}</p>
+          <div v-if="itemData?.ingredients" class="d-flex flex-wrap gap-2">
+            <span v-for="ing in itemData.ingredients.split(',')" :key="ing" class="badge bg-secondary">{{ ing.trim() }}</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="my-4">
+        <div class="d-flex justify-content-center gap-3 mb-3">
+          <button type="button" class="btn btn-outline-success btn-lg d-flex align-items-center gap-2">
+            <i class="bi bi-hand-thumbs-up-fill"></i>
+            <span>{{ itemData?.likes ?? 0 }}</span>
+            <span class="visually-hidden">Like</span>
+          </button>
+          <button type="button" class="btn btn-outline-danger btn-lg d-flex align-items-center gap-2">
+            <i class="bi bi-hand-thumbs-down-fill"></i>
+            <span>{{ itemData?.dislikes ?? 0 }}</span>
+            <span class="visually-hidden">Dislike</span>
+          </button>
+        </div>
+
+        <div class="d-flex flex-column align-items-center">
+          <span class="mb-2">Rate this item</span>
+          <div class="d-flex">
+            <template v-for="n in 5">
+              <input :id="'rate'+n" type="radio" class="btn-check" name="rating">
+              <label :for="'rate'+n" class="btn btn-sm btn-outline-warning me-1">
+                <i class="bi bi-star-fill"></i>
+                <span class="visually-hidden">{{ n }} star</span>
+              </label>
+            </template>
+          </div>
+        </div>
+      </div>
+
+      <div class="text-end mb-4">
+        <button class="btn btn-outline-primary" @click="win.navigator?.share && win.navigator?.share({ title: itemData?.name, url: win.location.href })">
+          <i class="bi bi-share-fill me-1"></i>Share
+        </button>
+      </div>
+    </div>
   </div>
-  
-  
-  
 
+  <div class="d-md-none fixed-bottom bg-dark py-2 border-top">
+    <div class="container d-flex justify-content-between">
+      <button class="btn btn-link text-decoration-none text-light" @click="win.history.back()">
+        <i class="bi bi-arrow-left-circle me-1"></i>Back to Menu
+      </button>
+      <button class="btn btn-link text-decoration-none text-light" @click="win.navigator?.share && win.navigator?.share({ title: itemData?.name, url: win.location.href })">
+        <i class="bi bi-share-fill me-1"></i>Share
+      </button>
+    </div>
+  </div>
 </template>
 
 <script lang="ts" setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, nextTick } from 'vue'
 import { useRoute } from 'vue-router'
 import Navbar from '../components/Navbar.vue';
 
@@ -77,6 +118,7 @@ const itemName = route.params.itemName as string
 const itemData = ref<any>(null)
 const isLoading = ref(true)
 const error = ref<string | null>(null)
+const win = window
 
 onMounted(async () => {
   try {
@@ -89,6 +131,29 @@ onMounted(async () => {
     error.value = err.message
   } finally {
     isLoading.value = false
+    await nextTick()
+    const els = document.querySelectorAll<HTMLElement>('.pk-reveal');
+    const io = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          const el = entry.target as HTMLElement;
+          const anim = el.dataset.anim || 'animate__fadeInUp';
+          const delay = Number(el.dataset.delay || 0);
+          setTimeout(() => {
+            el.classList.add('animate__animated', anim, 'pk-visible');
+          }, delay);
+          io.unobserve(el);
+        }
+      });
+    }, { threshold: 0.2 });
+    els.forEach((el) => io.observe(el));
   }
 })
 </script>
+
+<style scoped>
+.pk-reveal { opacity: 0; }
+.pk-visible { opacity: 1; }
+.pk-hero-img { object-fit: cover; }
+</style>
+


### PR DESCRIPTION
## Summary
- Refine item detail page with centered hero, header and tag badges
- Add feedback actions, share controls and mobile bottom bar
- Introduce IntersectionObserver for animated reveals

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b219f82648832387088b9c394025c4