### PR TITLE
Fix star rating selection and add user feedback

### DIFF
--- a/src/pages/ItemDetailPage.vue
+++ b/src/pages/ItemDetailPage.vue
@@ -5,7 +5,7 @@
     class="position-fixed top-0 start-50 translate-middle-x mt-3"
     style="z-index: 2000;"
   >
-    <div class="alert alert-success shadow" role="alert">{{ feedback }}</div>
+    <div class="alert alert-info shadow" role="alert">{{ feedback }}</div>
   </div>
 
   <div class="container py-3">

--- a/src/pages/ItemDetailPage.vue
+++ b/src/pages/ItemDetailPage.vue
@@ -1,5 +1,12 @@
 <template>
   <Navbar />
+  <div
+    v-if="showFeedback"
+    class="position-fixed top-0 start-50 translate-middle-x mt-3"
+    style="z-index: 2000;"
+  >
+    <div class="alert alert-success shadow" role="alert">{{ feedback }}</div>
+  </div>
 
   <div class="container py-3">
     <div v-if="isLoading" class="text-center py-5">
@@ -89,7 +96,6 @@
             <span class="visually-hidden">{{ n }} star</span>
           </button>
         </div>
-        <small v-if="feedback" class="mt-2 text-success">{{ feedback }}</small>
       </div>
 
       <div class="text-end mb-4">
@@ -117,10 +123,15 @@ const error = ref<string | null>(null)
 const win = window
 const rating = ref<number>(0)
 const feedback = ref('')
+const showFeedback = ref(false)
 
 const setRating = (n: number) => {
   rating.value = n
   feedback.value = `Thanks for rating ${n} star${n > 1 ? 's' : ''}!`
+  showFeedback.value = true
+  setTimeout(() => {
+    showFeedback.value = false
+  }, 2000)
 }
 
 onMounted(async () => {

--- a/src/pages/ItemDetailPage.vue
+++ b/src/pages/ItemDetailPage.vue
@@ -77,14 +77,19 @@
       <div class="my-4 d-flex flex-column align-items-center">
         <span class="mb-2">Rate this item</span>
         <div class="d-flex">
-          <template v-for="n in 5">
-            <input :id="'rate'+n" type="radio" class="btn-check" name="rating">
-            <label :for="'rate'+n" class="btn btn-sm btn-outline-primary me-1">
-              <i class="bi bi-star-fill"></i>
-              <span class="visually-hidden">{{ n }} star</span>
-            </label>
-          </template>
+          <button
+            v-for="n in 5"
+            :key="n"
+            type="button"
+            class="btn btn-sm me-1"
+            :class="n <= rating ? 'btn-primary' : 'btn-outline-primary'"
+            @click="setRating(n)"
+          >
+            <i class="bi bi-star-fill"></i>
+            <span class="visually-hidden">{{ n }} star</span>
+          </button>
         </div>
+        <small v-if="feedback" class="mt-2 text-success">{{ feedback }}</small>
       </div>
 
       <div class="text-end mb-4">
@@ -110,6 +115,13 @@ const itemData = ref<any>(null)
 const isLoading = ref(true)
 const error = ref<string | null>(null)
 const win = window
+const rating = ref<number>(0)
+const feedback = ref('')
+
+const setRating = (n: number) => {
+  rating.value = n
+  feedback.value = `Thanks for rating ${n} star${n > 1 ? 's' : ''}!`
+}
 
 onMounted(async () => {
   try {

--- a/src/pages/ItemDetailPage.vue
+++ b/src/pages/ItemDetailPage.vue
@@ -5,7 +5,7 @@
     class="position-fixed top-0 start-50 translate-middle-x mt-3"
     style="z-index: 2000;"
   >
-    <div class="alert alert-info shadow" role="alert">{{ feedback }}</div>
+    <div class="alert alert-warning shadow" role="alert">{{ feedback }}</div>
   </div>
 
   <div class="container py-3">


### PR DESCRIPTION
## Summary
- allow selecting multiple rating stars at once in ItemDetailPage
- display feedback message after rating

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b3688be208832391e2f7bb2f9b94f3