### PR TITLE
Add SEO meta tags and sitemap

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,18 +4,45 @@
 <head>
   <meta charset="UTF-8" />
   <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link
     href="https://fonts.googleapis.com/css2?family=Roboto+Slab:wght@400;700&family=Roboto:wght@400;500;700&display=swap"
-    rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=Urbanist:wght@400;700&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=Rufina:wght@400;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="/css/styles.css">
+    rel="stylesheet"
+  />
+  <link href="https://fonts.googleapis.com/css2?family=Urbanist:wght@400;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Rufina:wght@400;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="/css/styles.css" />
 
+  <!-- Primary Meta Tags -->
+  <title>Peshkash — Your Event, Digitally Presented</title>
+  <meta
+    name="description"
+    content="Peshkash lets guests at weddings, events, and exhibitions scan QR codes to instantly access digital menus, exhibits, and stories. Simple, elegant, and memorable."
+  />
+  <meta
+    name="keywords"
+    content="Peshkash, QR menus, digital menu, wedding tech, event technology, exhibitions, contactless menu India"
+  />
+  <meta name="robots" content="index, follow" />
+  <link rel="canonical" href="https://peshkash.app/" />
 
-  <title>Peshkash</title>
+  <!-- Open Graph / Facebook -->
+  <meta property="og:title" content="Peshkash — Your Event, Digitally Presented" />
+  <meta
+    property="og:description"
+    content="Guests scan QR codes to access digital menus, exhibits, and stories at weddings and events."
+  />
+  <meta property="og:image" content="https://peshkash.app/og-preview.jpg" />
+  <meta property="og:url" content="https://peshkash.app/" />
+  <meta property="og:type" content="website" />
+
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Peshkash — Your Event, Digitally Presented" />
+  <meta name="twitter:description" content="Elegant QR-powered digital menus and event content." />
+  <meta name="twitter:image" content="https://peshkash.app/og-preview.jpg" />
 </head>
 
 <body>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+Sitemap: https://peshkash.app/sitemap.xml
+User-agent: *
+Allow: /

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://peshkash.app/</loc>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://peshkash.app/#pricing</loc>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://peshkash.app/#contact</loc>
+    <priority>0.8</priority>
+  </url>
+  <!-- Add event/menu/item dynamic routes later -->
+</urlset>


### PR DESCRIPTION
## Summary
- add comprehensive SEO, Open Graph, and Twitter metadata to `index.html`
- provide sitemap and robots directives for search indexing
- remove binary placeholder image from `public`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b3738104648323ba91480c827872c2