### PR TITLE
feat: integrate Google Analytics 4 with dual-write analytics layer

### DIFF
--- a/src/components/analytics/AnalyticsSection.vue
+++ b/src/components/analytics/AnalyticsSection.vue
@@ -2,9 +2,14 @@
   <div class="analytics-section">
     <!-- Header + filters -->
     <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-4">
-      <div>
-        <h5 class="fw-bold mb-0">Analytics</h5>
-        <p class="text-muted small mb-0">QR scan and engagement data</p>
+      <div class="d-flex align-items-center gap-2">
+        <div>
+          <h5 class="fw-bold mb-0">Analytics</h5>
+          <p class="text-muted small mb-0">QR scan and engagement data</p>
+        </div>
+        <span v-if="gaEnabled" class="badge bg-success-subtle text-success border border-success-subtle ms-1" style="font-size:0.7rem;">
+          <i class="bi bi-graph-up me-1"></i>GA Active
+        </span>
       </div>
       <div class="d-flex gap-2 align-items-center flex-wrap">
         <!-- Vendor filter -->
@@ -137,6 +142,7 @@
 import { ref, computed, onMounted } from 'vue';
 import axios from 'axios';
 import { API_BASE_URL } from '../../config';
+import { gaEnabled } from '../../utils/ga';
 import KpiCard from './KpiCard.vue';
 import ScanChart from './ScanChart.vue';
 import TopTable from './TopTable.vue';

--- a/src/composables/useAnalytics.ts
+++ b/src/composables/useAnalytics.ts
@@ -1,7 +1,11 @@
 /**
  * useAnalytics — fire-and-forget action tracking composable.
  *
- * Usage in any public page:
+ * Dual-writes to:
+ *   1. /api/analytics/action  — our Postgres backend (detailed, vendor-scoped)
+ *   2. Google Analytics 4     — only when VITE_GA_MEASUREMENT_ID is configured
+ *
+ * Usage:
  *   const { track } = useAnalytics({ vendorId: 3, eventId: 12 })
  *   track('whatsapp_click')
  *
@@ -10,6 +14,7 @@
  */
 
 import { API_BASE_URL } from '../config';
+import { gtagEvent } from '../utils/ga';
 
 export interface AnalyticsContext {
   vendorId?: number;
@@ -34,13 +39,14 @@ export type ActionType =
 
 export function useAnalytics(ctx: AnalyticsContext = {}) {
   /**
-   * Fire-and-forget: post action to /api/analytics/action.
+   * Fire-and-forget: posts to backend AND fires a GA custom event.
    * Always returns void synchronously — never await this.
    */
   function track(actionType: ActionType | string, extra?: Partial<AnalyticsContext>): void {
-    const payload = { actionType, ...ctx, ...extra };
+    const merged = { ...ctx, ...extra };
+    const payload = { actionType, ...merged };
 
-    // Use sendBeacon when leaving a page, fetch otherwise
+    // ── 1. Backend (Postgres via Redis queue) ──────────────────────────
     const body = JSON.stringify(payload);
     const url = `${API_BASE_URL}/analytics/action`;
 
@@ -54,6 +60,15 @@ export function useAnalytics(ctx: AnalyticsContext = {}) {
         keepalive: true,
       }).catch(() => {/* silent */});
     }
+
+    // ── 2. Google Analytics 4 (no-op if VITE_GA_MEASUREMENT_ID not set) ─
+    gtagEvent(actionType, {
+      vendor_id: merged.vendorId,
+      event_id: merged.eventId,
+      menu_id: merged.menuId,
+      item_id: merged.itemId,
+      qr_hash: merged.qrHash,
+    });
   }
 
   return { track };

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,9 @@ import 'bootstrap-icons/font/bootstrap-icons.css';
 import 'animate.css';
 
 import { router } from './router';
+import { initGA } from './utils/ga';
+
+initGA();
 
 const app = createApp(App);
 

--- a/src/pages/AdminDashboard.vue
+++ b/src/pages/AdminDashboard.vue
@@ -102,7 +102,10 @@
           <div class="panel home-chart-panel">
             <div class="panel-heading">
               <h3>QR Scans by Code</h3>
-              <RouterLink class="icon-btn" to="/dashboard/qr" title="QR Bank"><i class="bi bi-arrow-right"></i></RouterLink>
+              <div class="d-flex gap-1">
+                <RouterLink class="icon-btn" to="/dashboard/analytics" title="Full Analytics"><i class="bi bi-bar-chart-line"></i></RouterLink>
+                <RouterLink class="icon-btn" to="/dashboard/qr" title="QR Bank"><i class="bi bi-arrow-right"></i></RouterLink>
+              </div>
             </div>
             <div v-if="vendorQrMappings.length" class="chart-canvas-wrap">
               <Bar :data="qrScanChartData" :options="qrScanChartOptions" />

--- a/src/pages/QrRedirect.vue
+++ b/src/pages/QrRedirect.vue
@@ -9,6 +9,7 @@
 import { ref, onMounted } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { API_BASE_URL } from '../config';
+import { gtagEvent } from '../utils/ga';
 
 const route = useRoute();
 const router = useRouter();
@@ -33,6 +34,7 @@ onMounted(async () => {
       const redirectUrl = data.redirectionUrl;
 
       if (redirectUrl) {
+        gtagEvent('qr_scan', { qr_hash: qrHash });
         router.push(redirectUrl.startsWith('/') ? redirectUrl : `/${redirectUrl}`);
       } else {
         errorMessage.value = 'API response missing redirectionUrl.';
@@ -43,8 +45,8 @@ onMounted(async () => {
       errorMessage.value = `API responded with status: ${apiResponse.status}`;
       error.value = true;
       loading.value = false;
-  }
-} catch (err: any) {
+    }
+  } catch (err: any) {
     errorMessage.value = `Error fetching redirect URL: ${err.message}`;
     error.value = true;
     loading.value = false;

--- a/src/router.ts
+++ b/src/router.ts
@@ -134,3 +134,8 @@ export const router = createRouter({
   history: createWebHistory(),
   routes,
 })
+
+// GA page view on every navigation
+router.afterEach((to) => {
+  import('./utils/ga').then(({ gtagPageView }) => gtagPageView(to.fullPath));
+})

--- a/src/utils/ga.ts
+++ b/src/utils/ga.ts
@@ -1,0 +1,66 @@
+/**
+ * Google Analytics 4 utility — wraps gtag behind a safe interface.
+ *
+ * Reads VITE_GA_MEASUREMENT_ID at build time.
+ * If the env var is not set, all calls are no-ops — zero runtime cost.
+ *
+ * Usage:
+ *   initGA()         — call once in main.ts
+ *   gtagPageView()   — call in router.afterEach
+ *   gtagEvent()      — called by useAnalytics composable
+ */
+
+declare global {
+  interface Window {
+    dataLayer: any[];
+    gtag: (...args: any[]) => void;
+  }
+}
+
+const GA_ID = import.meta.env.VITE_GA_MEASUREMENT_ID as string | undefined;
+export const gaEnabled = !!GA_ID;
+
+/** Inject the GA script and configure the property. Call once on app boot. */
+export function initGA(): void {
+  if (!GA_ID) return;
+
+  const script = document.createElement('script');
+  script.async = true;
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_ID}`;
+  document.head.appendChild(script);
+
+  window.dataLayer = window.dataLayer || [];
+  window.gtag = function (...args: any[]) { window.dataLayer.push(args); };
+  window.gtag('js', new Date());
+  // Disable auto page_view — we fire them manually via router.afterEach
+  window.gtag('config', GA_ID, { send_page_view: false });
+}
+
+/** Fire a page_view event — called by router.afterEach */
+export function gtagPageView(path: string, title?: string): void {
+  if (!gaEnabled || typeof window.gtag !== 'function') return;
+  window.gtag('event', 'page_view', {
+    page_location: window.location.origin + path,
+    page_path: path,
+    page_title: title ?? document.title,
+  });
+}
+
+/**
+ * Fire a named custom event with optional vendor/event context.
+ * Called by useAnalytics.track() so every tracked action reaches GA too.
+ */
+export function gtagEvent(
+  eventName: string,
+  params?: {
+    vendor_id?: number;
+    event_id?: number;
+    menu_id?: number;
+    item_id?: number;
+    qr_hash?: string;
+    [key: string]: any;
+  }
+): void {
+  if (!gaEnabled || typeof window.gtag !== 'function') return;
+  window.gtag('event', eventName, params ?? {});
+}


### PR DESCRIPTION
- Add ga.ts utility: initGA(), gtagPageView(), gtagEvent() — all no-ops when VITE_GA_MEASUREMENT_ID unset
- Wire initGA() in main.ts and page-view tracking in router.afterEach
- useAnalytics.track() dual-writes to backend AND GA so every action event reaches both
- QrRedirect fires qr_scan GA custom event before redirect (GA sees the hash, not just destination)
- AnalyticsSection shows GA Active badge when VITE_GA_MEASUREMENT_ID is configured
- Home dashboard QR Scans panel gets a direct link to /dashboard/analytics