### PR TITLE
feat(analytics-v5): drawer UX + item breakdown table

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -3,8 +3,8 @@
   "configurations": [
     {
       "name": "peshkash-frontend",
-      "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "dev"],
+      "runtimeExecutable": "node_modules\\.bin\\vite.cmd",
+      "runtimeArgs": ["--port", "5177"],
       "port": 5177
     }
   ]

--- a/src/components/analytics/AnalyticsDrawer.vue
+++ b/src/components/analytics/AnalyticsDrawer.vue
@@ -1,0 +1,214 @@
+<template>
+  <Teleport to="body">
+    <Transition name="adrawer-fade">
+      <div
+        v-if="modelValue"
+        class="adrawer-backdrop"
+        @click.self="close"
+        @keydown.esc="close"
+        tabindex="-1"
+      >
+        <Transition name="adrawer-slide" appear>
+          <div v-if="modelValue" class="adrawer-panel" role="dialog" :aria-label="title">
+            <!-- Header -->
+            <div class="adrawer-header">
+              <div class="adrawer-title-row">
+                <div v-if="icon" class="adrawer-icon">
+                  <i :class="icon"></i>
+                </div>
+                <div class="adrawer-title-block">
+                  <h5 class="adrawer-title">{{ title }}</h5>
+                  <p v-if="subtitle" class="adrawer-subtitle">{{ subtitle }}</p>
+                </div>
+              </div>
+              <!-- Right-side slot for range selector, etc. -->
+              <div class="adrawer-header-actions">
+                <slot name="header-actions" />
+                <button class="adrawer-close-btn" @click="close" aria-label="Close">
+                  <i class="bi bi-x-lg"></i>
+                </button>
+              </div>
+            </div>
+            <!-- Scrollable body -->
+            <div class="adrawer-body">
+              <slot />
+            </div>
+          </div>
+        </Transition>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { watch } from 'vue';
+
+const props = defineProps<{
+  modelValue: boolean;
+  title?: string;
+  subtitle?: string;
+  icon?: string;
+}>();
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', val: boolean): void;
+}>();
+
+function close() { emit('update:modelValue', false); }
+
+// Lock body scroll while drawer is open
+watch(() => props.modelValue, open => {
+  if (open) {
+    document.body.style.overflow = 'hidden';
+  } else {
+    document.body.style.overflow = '';
+  }
+}, { immediate: false });
+</script>
+
+<style scoped>
+/* ── Backdrop ──────────────────────────────────────────────────────────────── */
+.adrawer-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1060;
+  background: rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(3px);
+  display: flex;
+  justify-content: flex-end;
+  outline: none;
+}
+
+/* ── Panel ─────────────────────────────────────────────────────────────────── */
+.adrawer-panel {
+  position: relative;
+  width: 100%;
+  max-width: 560px;
+  height: 100%;
+  background: var(--bs-body-bg, #fff);
+  box-shadow: -6px 0 32px rgba(0, 0, 0, 0.14);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* Mobile: bottom sheet */
+@media (max-width: 767px) {
+  .adrawer-backdrop {
+    align-items: flex-end;
+    justify-content: stretch;
+  }
+  .adrawer-panel {
+    max-width: 100%;
+    width: 100%;
+    height: 92dvh;
+    border-radius: 20px 20px 0 0;
+  }
+}
+
+/* ── Header ────────────────────────────────────────────────────────────────── */
+.adrawer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--bs-border-color, #dee2e6);
+  flex-shrink: 0;
+  min-width: 0;
+}
+.adrawer-title-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  min-width: 0;
+  flex: 1;
+}
+.adrawer-icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  background: var(--bs-primary-bg-subtle, #e8efff);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  color: var(--bs-primary);
+  flex-shrink: 0;
+}
+.adrawer-title-block { min-width: 0; }
+.adrawer-title {
+  font-size: 0.95rem;
+  font-weight: 700;
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.adrawer-subtitle {
+  font-size: 0.75rem;
+  color: var(--bs-secondary-color, #6c757d);
+  margin: 2px 0 0;
+}
+
+.adrawer-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+.adrawer-close-btn {
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: var(--bs-light, #f8f9fa);
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: var(--bs-secondary-color, #6c757d);
+  font-size: 0.85rem;
+  transition: background 0.15s, color 0.15s;
+}
+.adrawer-close-btn:hover {
+  background: var(--bs-secondary-bg, #e9ecef);
+  color: var(--bs-body-color);
+}
+
+/* ── Body ──────────────────────────────────────────────────────────────────── */
+.adrawer-body {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 1.25rem;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* ── Transitions ────────────────────────────────────────────────────────────── */
+/* Backdrop fade */
+.adrawer-fade-enter-active,
+.adrawer-fade-leave-active { transition: opacity 0.22s ease; }
+.adrawer-fade-enter-from,
+.adrawer-fade-leave-to { opacity: 0; }
+
+/* Panel slide (desktop: from right) */
+.adrawer-slide-enter-active {
+  transition: transform 0.28s cubic-bezier(0.32, 0.72, 0, 1);
+}
+.adrawer-slide-leave-active {
+  transition: transform 0.2s ease-in;
+}
+.adrawer-slide-enter-from,
+.adrawer-slide-leave-to {
+  transform: translateX(100%);
+}
+
+/* Panel slide (mobile: from bottom) */
+@media (max-width: 767px) {
+  .adrawer-slide-enter-from,
+  .adrawer-slide-leave-to {
+    transform: translateY(100%);
+  }
+}
+</style>

--- a/src/components/analytics/AnalyticsSection.vue
+++ b/src/components/analytics/AnalyticsSection.vue
@@ -277,22 +277,35 @@
         </div>
       </div>
 
-      <!-- Inline analytics panel -->
-      <div v-if="drilldownTarget" class="drilldown-panel mt-3">
-        <EventAnalyticsPanel
-          v-if="drilldownTarget.type === 'event'"
-          :event-id="drilldownTarget.id"
-          :event-name="drilldownTarget.name"
-        />
-        <VendorAnalyticsPanel
-          v-else-if="drilldownTarget.type === 'vendor'"
-          :vendor-id="drilldownTarget.id"
-          :vendor-name="drilldownTarget.name"
-          @close="drilldownTarget = null"
-        />
-      </div>
+      <!-- No inline panel: clicking opens a drawer -->
+      <p v-if="!drilldownEvents.length && !drilldownVendors.length" class="text-muted small text-center py-3">
+        No resources found for the selected filter.
+      </p>
     </div>
   </div>
+
+  <!-- ── Event detail drawer ─────────────────────────────────────────────── -->
+  <EventDetailDrawer
+    v-if="drawerTarget?.type === 'event'"
+    v-model="drawerOpen"
+    :event-id="drawerTarget.id"
+    :event-name="drawerTarget.name"
+  />
+
+  <!-- ── Vendor detail drawer ────────────────────────────────────────────── -->
+  <AnalyticsDrawer
+    v-if="drawerTarget?.type === 'vendor'"
+    v-model="drawerOpen"
+    icon="bi bi-person-vcard"
+    :title="drawerTarget.name"
+    subtitle="Contact Card Analytics"
+  >
+    <VendorAnalyticsPanel
+      :vendor-id="drawerTarget.id"
+      :vendor-name="drawerTarget.name"
+      @close="drawerOpen = false"
+    />
+  </AnalyticsDrawer>
 </template>
 
 <script setup lang="ts">
@@ -305,7 +318,8 @@ import ScanChart from './ScanChart.vue';
 import ActionBreakdown from './ActionBreakdown.vue';
 import DeviceSplit from './DeviceSplit.vue';
 import TopItemsTable from './TopItemsTable.vue';
-import EventAnalyticsPanel from './EventAnalyticsPanel.vue';
+import EventDetailDrawer from './EventDetailDrawer.vue';
+import AnalyticsDrawer from './AnalyticsDrawer.vue';
 import VendorAnalyticsPanel from './VendorAnalyticsPanel.vue';
 
 interface Vendor { id: number; displayName: string; name: string }
@@ -348,7 +362,10 @@ const range = ref<RangeValue>('30d');
 // Drill-down state
 type ResourceTab = 'events' | 'contacts';
 const resourceTab = ref<ResourceTab>('events');
+// drilldownTarget drives active-card highlight; drawerTarget/drawerOpen drive the drawer
 const drilldownTarget = ref<{ type: 'event' | 'vendor'; id: number; name: string } | null>(null);
+const drawerTarget = ref<{ type: 'event' | 'vendor'; id: number; name: string } | null>(null);
+const drawerOpen = ref(false);
 const allEvents = ref<EventResource[]>([]);
 const drilldownVendors = ref<Vendor[]>([]);
 
@@ -365,15 +382,19 @@ const resourceTabs = computed(() => [
 
 watch(selectedVendorId, () => {
   drilldownTarget.value = null;
+  drawerOpen.value = false;
 });
 
 function selectDrilldown(type: 'event' | 'vendor', id: number, name: string) {
-  if (drilldownTarget.value?.type === type && drilldownTarget.value.id === id) {
-    drilldownTarget.value = null; // toggle off
-  } else {
-    drilldownTarget.value = { type, id, name };
-  }
+  drilldownTarget.value = { type, id, name };
+  drawerTarget.value = { type, id, name };
+  drawerOpen.value = true;
 }
+
+// Clear active card when drawer is closed
+watch(drawerOpen, open => {
+  if (!open) drilldownTarget.value = null;
+});
 
 const topQrDetails = computed(() => summary.value?.topQrDetails ?? []);
 
@@ -545,5 +566,5 @@ onMounted(async () => {
 .resource-card-meta { margin-top: 2px; }
 .resource-card-arrow { color: var(--bs-secondary-color, #6c757d); font-size: 0.75rem; }
 .resource-empty { display: flex; align-items: center; gap: 0.5rem; color: var(--bs-secondary-color, #6c757d); font-size: 0.85rem; padding: 1.5rem; justify-content: center; }
-.drilldown-panel { border: 1px solid var(--bs-border-color, #dee2e6); border-radius: 12px; overflow: hidden; }
+/* .drilldown-panel removed — analytics now open in AnalyticsDrawer */
 </style>

--- a/src/components/analytics/EventDetailDrawer.vue
+++ b/src/components/analytics/EventDetailDrawer.vue
@@ -1,0 +1,299 @@
+<template>
+  <AnalyticsDrawer
+    :model-value="modelValue"
+    @update:model-value="$emit('update:modelValue', $event)"
+    icon="bi bi-calendar2-week"
+    :title="eventName"
+    subtitle="Event Analytics"
+  >
+    <!-- Range selector in header -->
+    <template #header-actions>
+      <div class="btn-group btn-group-sm">
+        <button
+          v-for="r in RANGES"
+          :key="r.value"
+          type="button"
+          class="btn btn-outline-secondary"
+          :class="{ active: range === r.value }"
+          @click="setRange(r.value)"
+        >{{ r.label }}</button>
+      </div>
+    </template>
+
+    <!-- Loading -->
+    <div v-if="loading" class="row g-2 mb-3">
+      <div v-for="n in 4" :key="n" class="col-6">
+        <div class="card border-0 shadow-sm placeholder-glow" style="height:76px;border-radius:10px;">
+          <div class="card-body"><span class="placeholder col-8 rounded"></span></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Error -->
+    <div v-else-if="error" class="alert alert-warning py-2 small">
+      <i class="bi bi-exclamation-triangle me-1"></i>Analytics unavailable.
+    </div>
+
+    <!-- Empty -->
+    <div v-else-if="!summary || summary.totalScans === 0 && !itemHasData" class="edd-empty">
+      <i class="bi bi-qr-code-scan"></i>
+      <p class="mb-1 fw-medium">No data yet</p>
+      <p class="mb-0">Analytics will appear after customers scan this event's QR code.</p>
+    </div>
+
+    <template v-else-if="summary">
+      <!-- Summary sentence -->
+      <p class="edd-summary-text mb-3">
+        <strong>{{ eventName }}</strong> received
+        <strong>{{ summary.totalScans }} scan{{ summary.totalScans !== 1 ? 's' : '' }}</strong>
+        and <strong>{{ summary.totalActions }} action{{ summary.totalActions !== 1 ? 's' : '' }}</strong>.
+        <span v-if="engagementRate > 0"> Engagement rate: <strong>{{ engagementRate }}%</strong>.</span>
+      </p>
+
+      <!-- KPIs: 2-up on mobile, 4-up on wider -->
+      <div class="row g-2 mb-3">
+        <div class="col-6">
+          <div class="edd-kpi-card">
+            <div class="edd-kpi-icon text-primary"><i class="bi bi-qr-code-scan"></i></div>
+            <div class="edd-kpi-val">{{ summary.totalScans }}</div>
+            <div class="edd-kpi-label">Scans</div>
+          </div>
+        </div>
+        <div class="col-6">
+          <div class="edd-kpi-card">
+            <div class="edd-kpi-icon text-warning"><i class="bi bi-eye"></i></div>
+            <div class="edd-kpi-val">{{ itemViewCount }}</div>
+            <div class="edd-kpi-label">Item Views</div>
+          </div>
+        </div>
+        <div class="col-6">
+          <div class="edd-kpi-card">
+            <div class="edd-kpi-icon text-success"><i class="bi bi-cursor-fill"></i></div>
+            <div class="edd-kpi-val">{{ summary.totalActions }}</div>
+            <div class="edd-kpi-label">Actions</div>
+          </div>
+        </div>
+        <div class="col-6">
+          <div class="edd-kpi-card">
+            <div class="edd-kpi-icon" style="color:#7c3aed"><i class="bi bi-arrow-repeat"></i></div>
+            <div class="edd-kpi-val">{{ engagementRate }}%</div>
+            <div class="edd-kpi-label">Engagement</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Scans Over Time -->
+      <div class="card border-0 shadow-sm mb-4">
+        <div class="card-body pb-2">
+          <h6 class="fw-semibold mb-2 small text-uppercase text-muted">Scans Over Time</h6>
+          <ScanChart :data="summary.scansPerDay" />
+        </div>
+      </div>
+
+      <!-- Actions breakdown (compact bar list) -->
+      <div v-if="topActions.length" class="card border-0 shadow-sm mb-4">
+        <div class="card-body">
+          <h6 class="fw-semibold mb-3 small text-uppercase text-muted">Top Actions</h6>
+          <div v-for="(a, i) in topActions" :key="a.actionType" class="edd-action-row">
+            <span class="edd-action-label">{{ ACTION_LABEL[a.actionType] ?? a.actionType }}</span>
+            <div class="edd-action-bar-wrap">
+              <div
+                class="edd-action-bar"
+                :style="{ width: (topActions[0].count ? (a.count / topActions[0].count) * 100 : 0) + '%' }"
+                :class="['edd-bar-color-' + (i % 5)]"
+              ></div>
+            </div>
+            <span class="edd-action-count">{{ a.count }}</span>
+          </div>
+        </div>
+      </div>
+    </template>
+
+    <!-- Items breakdown table — always shown when event has data -->
+    <div class="edd-items-section">
+      <div class="d-flex align-items-center justify-content-between mb-2">
+        <h6 class="fw-semibold mb-0 small text-uppercase text-muted">Items Detail</h6>
+        <span class="badge bg-secondary-subtle text-secondary border" style="font-size:0.7rem;">sortable · searchable</span>
+      </div>
+      <ItemBreakdownTable :event-id="eventId" :range="range" />
+    </div>
+  </AnalyticsDrawer>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, onMounted } from 'vue';
+import axios from 'axios';
+import { API_BASE_URL } from '../../config';
+import AnalyticsDrawer from './AnalyticsDrawer.vue';
+import ScanChart from './ScanChart.vue';
+import ItemBreakdownTable from './ItemBreakdownTable.vue';
+
+const props = defineProps<{
+  modelValue: boolean;
+  eventId: number;
+  eventName: string;
+}>();
+
+defineEmits<{
+  (e: 'update:modelValue', val: boolean): void;
+}>();
+
+const RANGES = [
+  { label: '7D', value: '7d' },
+  { label: '30D', value: '30d' },
+  { label: '90D', value: '90d' },
+  { label: 'All', value: 'all' },
+] as const;
+type RangeValue = typeof RANGES[number]['value'];
+
+const ACTION_LABEL: Record<string, string> = {
+  whatsapp_click: 'WhatsApp', call_click: 'Phone Call', email_click: 'Email',
+  directions_click: 'Directions', share_click: 'Share', save_contact: 'Save Contact',
+  social_click: 'Social', item_expand: 'Item Expand',
+  item_detail_view: 'Item Detail', menu_view: 'Menu View',
+  vendor_contact_view: 'Contact View',
+};
+
+interface Summary {
+  totalScans: number;
+  totalActions: number;
+  scansPerDay: Array<{ date: string; count: number }>;
+  actionBreakdown: Array<{ actionType: string; count: number }>;
+  topItemsViewed: Array<{ itemId: number; itemName: string; views: number }>;
+  lastActivity: string | null;
+}
+
+const loading = ref(false);
+const error = ref(false);
+const summary = ref<Summary | null>(null);
+const range = ref<RangeValue>('30d');
+
+const engagementRate = computed(() => {
+  const s = summary.value?.totalScans ?? 0;
+  return s ? Math.round(((summary.value?.totalActions ?? 0) / s) * 100) : 0;
+});
+
+const itemViewCount = computed(() => {
+  const b = summary.value?.actionBreakdown ?? [];
+  const expand = b.find(a => a.actionType === 'item_expand')?.count ?? 0;
+  const detail = b.find(a => a.actionType === 'item_detail_view')?.count ?? 0;
+  return expand + detail;
+});
+
+const topActions = computed(() =>
+  (summary.value?.actionBreakdown ?? []).slice(0, 5)
+);
+
+const itemHasData = computed(() =>
+  (summary.value?.topItemsViewed?.length ?? 0) > 0
+);
+
+function setRange(v: RangeValue) { range.value = v; load(); }
+
+async function load() {
+  if (!props.eventId) return;
+  loading.value = true;
+  error.value = false;
+  try {
+    const { data } = await axios.get<Summary>(`${API_BASE_URL}/analytics/summary`, {
+      params: { range: range.value, eventId: props.eventId },
+    });
+    summary.value = data;
+  } catch {
+    error.value = true;
+  } finally {
+    loading.value = false;
+  }
+}
+
+// Reload when opened or event changes
+watch(() => [props.modelValue, props.eventId], ([open]) => {
+  if (open) load();
+});
+onMounted(() => { if (props.modelValue) load(); });
+</script>
+
+<style scoped>
+/* KPI cards */
+.edd-kpi-card {
+  padding: 0.75rem;
+  border: 1px solid var(--bs-border-color, #dee2e6);
+  border-radius: 10px;
+  background: var(--bs-body-bg, #fff);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.edd-kpi-icon { font-size: 1rem; margin-bottom: 4px; }
+.edd-kpi-val { font-size: 1.4rem; font-weight: 700; line-height: 1.1; }
+.edd-kpi-label { font-size: 0.72rem; color: var(--bs-secondary-color, #6c757d); font-weight: 500; text-transform: uppercase; letter-spacing: 0.03em; }
+
+/* Summary text */
+.edd-summary-text { font-size: 0.875rem; color: var(--bs-secondary-color, #6c757d); line-height: 1.6; }
+
+/* Action bars */
+.edd-action-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+.edd-action-label {
+  font-size: 0.78rem;
+  color: var(--bs-body-color);
+  width: 110px;
+  flex-shrink: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.edd-action-bar-wrap {
+  flex: 1;
+  height: 8px;
+  background: var(--bs-light, #f0f0f0);
+  border-radius: 4px;
+  overflow: hidden;
+}
+.edd-action-bar {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 0.4s ease;
+  min-width: 4px;
+}
+.edd-bar-color-0 { background: #6366f1; }
+.edd-bar-color-1 { background: #22c55e; }
+.edd-bar-color-2 { background: #f59e0b; }
+.edd-bar-color-3 { background: #ec4899; }
+.edd-bar-color-4 { background: #14b8a6; }
+.edd-action-count {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--bs-secondary-color, #6c757d);
+  width: 28px;
+  text-align: right;
+  flex-shrink: 0;
+}
+
+/* Items section */
+.edd-items-section {
+  border-top: 1px solid var(--bs-border-color, #dee2e6);
+  padding-top: 1rem;
+  margin-top: 0.5rem;
+}
+
+/* Empty state */
+.edd-empty {
+  text-align: center;
+  padding: 3rem 1rem;
+  color: var(--bs-secondary-color, #6c757d);
+}
+.edd-empty i { font-size: 2.5rem; opacity: 0.2; display: block; margin-bottom: 0.75rem; }
+.edd-empty p { font-size: 0.875rem; }
+
+/* Range toggle active state */
+.btn-group .btn.active {
+  background-color: var(--bs-primary);
+  color: #fff;
+  border-color: var(--bs-primary);
+}
+</style>

--- a/src/components/analytics/ItemBreakdownTable.vue
+++ b/src/components/analytics/ItemBreakdownTable.vue
@@ -1,0 +1,381 @@
+<template>
+  <div class="item-breakdown">
+    <!-- Toolbar -->
+    <div class="ibt-toolbar">
+      <div class="ibt-search-wrap">
+        <i class="bi bi-search ibt-search-icon"></i>
+        <input
+          v-model="search"
+          type="text"
+          class="ibt-search"
+          placeholder="Search items…"
+        />
+        <button v-if="search" class="ibt-search-clear" @click="search = ''" aria-label="Clear">
+          <i class="bi bi-x"></i>
+        </button>
+      </div>
+      <div class="ibt-meta">
+        <span class="text-muted small">{{ sorted.length }} item{{ sorted.length !== 1 ? 's' : '' }}</span>
+      </div>
+    </div>
+
+    <!-- Loading -->
+    <div v-if="loading" class="placeholder-glow py-2">
+      <span class="placeholder col-12 rounded mb-2" style="height:30px;"></span>
+      <span v-for="n in 5" :key="n" class="placeholder col-12 rounded mb-1" style="height:22px;"></span>
+    </div>
+
+    <!-- Error -->
+    <div v-else-if="error" class="alert alert-warning py-2 small mt-2">
+      <i class="bi bi-exclamation-triangle me-1"></i>Could not load item data.
+    </div>
+
+    <!-- Empty state -->
+    <div v-else-if="!rows.length" class="ibt-empty">
+      <i class="bi bi-box-seam"></i>
+      <span>No item interactions recorded yet in this period.</span>
+    </div>
+
+    <!-- Table -->
+    <div v-else class="table-responsive ibt-table-wrap">
+      <table class="table table-sm table-hover align-middle mb-0 ibt-table">
+        <thead class="table-light">
+          <tr>
+            <th class="ibt-th-name">
+              <button class="ibt-sort-btn" @click="toggleSort('itemName')">
+                Item
+                <i class="bi" :class="sortIcon('itemName')"></i>
+              </button>
+            </th>
+            <th class="text-center ibt-col-sm">
+              <button class="ibt-sort-btn" @click="toggleSort('expands')" title="Item Expand clicks">
+                Expands <i class="bi" :class="sortIcon('expands')"></i>
+              </button>
+            </th>
+            <th class="text-center ibt-col-sm d-none d-sm-table-cell">
+              <button class="ibt-sort-btn" @click="toggleSort('detailViews')" title="Item Detail View clicks">
+                Detail <i class="bi" :class="sortIcon('detailViews')"></i>
+              </button>
+            </th>
+            <th class="text-center ibt-col-sm d-none d-md-table-cell">
+              <button class="ibt-sort-btn" @click="toggleSort('whatsappClicks')" title="WhatsApp clicks">
+                <i class="bi bi-whatsapp text-success"></i>
+                <i class="bi" :class="sortIcon('whatsappClicks')"></i>
+              </button>
+            </th>
+            <th class="text-center ibt-col-sm d-none d-md-table-cell">
+              <button class="ibt-sort-btn" @click="toggleSort('shareClicks')" title="Share clicks">
+                Share <i class="bi" :class="sortIcon('shareClicks')"></i>
+              </button>
+            </th>
+            <th class="text-center ibt-col-sm d-none d-lg-table-cell">
+              <button class="ibt-sort-btn" @click="toggleSort('directions')" title="Directions clicks">
+                Dir. <i class="bi" :class="sortIcon('directions')"></i>
+              </button>
+            </th>
+            <th class="text-center ibt-col-sm d-none d-lg-table-cell">
+              <button class="ibt-sort-btn" @click="toggleSort('calls')" title="Call clicks">
+                Calls <i class="bi" :class="sortIcon('calls')"></i>
+              </button>
+            </th>
+            <th class="text-center ibt-col-total">
+              <button class="ibt-sort-btn" @click="toggleSort('totalActions')">
+                Total <i class="bi" :class="sortIcon('totalActions')"></i>
+              </button>
+            </th>
+            <th class="text-end d-none d-sm-table-cell ibt-col-date">
+              <button class="ibt-sort-btn" @click="toggleSort('lastActivity')">
+                Last <i class="bi" :class="sortIcon('lastActivity')"></i>
+              </button>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="(row, i) in sorted" :key="row.itemId">
+            <td class="ibt-td-name">
+              <div class="ibt-item-name">{{ row.itemName }}</div>
+              <span
+                v-if="row.itemType && row.itemType !== 'item'"
+                class="ibt-type-badge"
+              >{{ row.itemType }}</span>
+            </td>
+            <td class="text-center">
+              <span :class="row.expands ? 'fw-semibold' : 'text-muted'">
+                {{ row.expands || '—' }}
+              </span>
+            </td>
+            <td class="text-center d-none d-sm-table-cell">
+              <span :class="row.detailViews ? 'fw-semibold' : 'text-muted'">
+                {{ row.detailViews || '—' }}
+              </span>
+            </td>
+            <td class="text-center d-none d-md-table-cell">
+              <span :class="row.whatsappClicks ? 'text-success fw-semibold' : 'text-muted'">
+                {{ row.whatsappClicks || '—' }}
+              </span>
+            </td>
+            <td class="text-center d-none d-md-table-cell">
+              <span :class="row.shareClicks ? 'fw-semibold' : 'text-muted'">
+                {{ row.shareClicks || '—' }}
+              </span>
+            </td>
+            <td class="text-center d-none d-lg-table-cell">
+              <span :class="row.directions ? 'fw-semibold' : 'text-muted'">
+                {{ row.directions || '—' }}
+              </span>
+            </td>
+            <td class="text-center d-none d-lg-table-cell">
+              <span :class="row.calls ? 'fw-semibold' : 'text-muted'">
+                {{ row.calls || '—' }}
+              </span>
+            </td>
+            <td class="text-center">
+              <span
+                class="ibt-total-badge"
+                :class="row.totalActions > 0 ? 'ibt-total-active' : 'ibt-total-zero'"
+              >{{ row.totalActions }}</span>
+            </td>
+            <td class="text-end text-muted small d-none d-sm-table-cell">
+              {{ formatDate(row.lastActivity) }}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Column legend on mobile -->
+    <div class="ibt-legend d-sm-none">
+      <span><strong>Exp</strong> = Item Expands</span>
+      <span class="ms-3"><strong>Tot</strong> = Total Actions</span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, onMounted } from 'vue';
+import axios from 'axios';
+import { API_BASE_URL } from '../../config';
+
+interface ItemRow {
+  itemId: number;
+  itemName: string;
+  itemType: string;
+  expands: number;
+  detailViews: number;
+  whatsappClicks: number;
+  shareClicks: number;
+  directions: number;
+  saves: number;
+  calls: number;
+  totalActions: number;
+  lastActivity: string | null;
+}
+
+type SortKey = keyof ItemRow;
+
+const props = defineProps<{
+  eventId: number;
+  range: string;
+}>();
+
+const loading = ref(false);
+const error = ref(false);
+const rows = ref<ItemRow[]>([]);
+const search = ref('');
+const sortKey = ref<SortKey>('totalActions');
+const sortDir = ref<'asc' | 'desc'>('desc');
+
+function toggleSort(key: SortKey) {
+  if (sortKey.value === key) {
+    sortDir.value = sortDir.value === 'desc' ? 'asc' : 'desc';
+  } else {
+    sortKey.value = key;
+    sortDir.value = 'desc';
+  }
+}
+
+function sortIcon(key: SortKey) {
+  if (sortKey.value !== key) return 'bi-chevron-expand text-muted opacity-50';
+  return sortDir.value === 'desc' ? 'bi-chevron-down' : 'bi-chevron-up';
+}
+
+const filtered = computed(() => {
+  const q = search.value.toLowerCase().trim();
+  return q ? rows.value.filter(r => r.itemName?.toLowerCase().includes(q)) : rows.value;
+});
+
+const sorted = computed(() => {
+  return [...filtered.value].sort((a, b) => {
+    const av = a[sortKey.value];
+    const bv = b[sortKey.value];
+    if (av === null || av === undefined) return 1;
+    if (bv === null || bv === undefined) return -1;
+    const cmp = av < bv ? -1 : av > bv ? 1 : 0;
+    return sortDir.value === 'asc' ? cmp : -cmp;
+  });
+});
+
+function formatDate(iso: string | null) {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  const diffDays = Math.floor((Date.now() - d.getTime()) / 86_400_000);
+  if (diffDays === 0) return 'Today';
+  if (diffDays === 1) return 'Yesterday';
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return d.toLocaleDateString('en-IN', { day: 'numeric', month: 'short' });
+}
+
+async function load() {
+  if (!props.eventId) return;
+  loading.value = true;
+  error.value = false;
+  try {
+    const { data } = await axios.get<ItemRow[]>(
+      `${API_BASE_URL}/analytics/events/${props.eventId}/items`,
+      { params: { range: props.range } }
+    );
+    rows.value = data ?? [];
+  } catch {
+    error.value = true;
+  } finally {
+    loading.value = false;
+  }
+}
+
+watch(() => [props.eventId, props.range], load);
+onMounted(load);
+</script>
+
+<style scoped>
+/* ── Toolbar ────────────────────────────────────────────────────────────────── */
+.ibt-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+  flex-wrap: wrap;
+}
+.ibt-search-wrap {
+  position: relative;
+  flex: 1;
+  min-width: 140px;
+}
+.ibt-search-icon {
+  position: absolute;
+  left: 0.6rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--bs-secondary-color, #6c757d);
+  font-size: 0.8rem;
+  pointer-events: none;
+}
+.ibt-search {
+  width: 100%;
+  padding: 0.35rem 2rem 0.35rem 1.8rem;
+  border: 1px solid var(--bs-border-color, #dee2e6);
+  border-radius: 8px;
+  font-size: 0.85rem;
+  background: var(--bs-body-bg, #fff);
+  color: var(--bs-body-color);
+  outline: none;
+  transition: border-color 0.15s;
+}
+.ibt-search:focus { border-color: var(--bs-primary); }
+.ibt-search-clear {
+  position: absolute;
+  right: 0.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  border: none;
+  background: none;
+  padding: 0;
+  font-size: 1rem;
+  color: var(--bs-secondary-color, #6c757d);
+  cursor: pointer;
+  line-height: 1;
+}
+.ibt-meta { white-space: nowrap; }
+
+/* ── Table ──────────────────────────────────────────────────────────────────── */
+.ibt-table-wrap { border-radius: 10px; border: 1px solid var(--bs-border-color, #dee2e6); overflow: hidden; }
+.ibt-table th { font-size: 0.72rem; font-weight: 600; padding: 0.5rem 0.5rem; white-space: nowrap; }
+.ibt-table td { font-size: 0.82rem; padding: 0.45rem 0.5rem; }
+.ibt-table tbody tr:last-child td { border-bottom: none; }
+
+.ibt-sort-btn {
+  border: none;
+  background: none;
+  padding: 0;
+  font-size: inherit;
+  font-weight: inherit;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  color: inherit;
+  white-space: nowrap;
+}
+.ibt-sort-btn:hover { color: var(--bs-primary); }
+
+/* Column widths */
+.ibt-th-name { min-width: 140px; }
+.ibt-col-sm { width: 54px; }
+.ibt-col-total { width: 60px; }
+.ibt-col-date { width: 80px; white-space: nowrap; }
+
+/* Item cell */
+.ibt-td-name { max-width: 180px; }
+.ibt-item-name {
+  font-weight: 500;
+  font-size: 0.83rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 170px;
+}
+.ibt-type-badge {
+  display: inline-block;
+  font-size: 0.65rem;
+  background: var(--bs-light, #f0f0f0);
+  color: var(--bs-secondary-color, #6c757d);
+  border-radius: 4px;
+  padding: 1px 5px;
+  margin-top: 1px;
+  text-transform: capitalize;
+}
+
+/* Total badge */
+.ibt-total-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 26px;
+  padding: 2px 6px;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+.ibt-total-active { background: var(--bs-primary-bg-subtle, #dde8ff); color: var(--bs-primary); }
+.ibt-total-zero { background: var(--bs-light, #f0f0f0); color: var(--bs-secondary-color, #6c757d); }
+
+/* Empty state */
+.ibt-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 2.5rem 1rem;
+  color: var(--bs-secondary-color, #6c757d);
+  font-size: 0.88rem;
+  text-align: center;
+}
+.ibt-empty i { font-size: 2rem; opacity: 0.25; }
+
+/* Legend */
+.ibt-legend {
+  margin-top: 0.5rem;
+  font-size: 0.72rem;
+  color: var(--bs-secondary-color, #6c757d);
+  padding: 0 0.25rem;
+}
+</style>


### PR DESCRIPTION
- Add AnalyticsDrawer.vue — right side-drawer on desktop, bottom sheet on mobile
- Add ItemBreakdownTable.vue — sortable/searchable table with per-action columns (expands, detail views, WhatsApp, share, directions, calls, total)
- Add EventDetailDrawer.vue — self-contained event drawer with KPIs, scan chart, action bars, and the full item breakdown table
- Update AnalyticsSection.vue: resource cards now open drawers instead of inline panels; keeps active-card highlight while drawer is open