### PR TITLE
feat(auth-v1): OTP login gate, Pinia auth store, vendor workspace lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "bootstrap": "^5.3.7",
         "bootstrap-icons": "^1.13.1",
         "chart.js": "^4.5.1",
+        "pinia": "^3.0.4",
         "primeflex": "^3.3.1",
         "primeicons": "^5.0.0",
         "primevue": "^4.3.2",
@@ -3088,6 +3089,30 @@
       "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
       "license": "MIT"
     },
+    "node_modules/@vue/devtools-kit": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
+      "integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^7.7.9",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
+      "integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
+      "license": "MIT",
+      "dependencies": {
+        "rfdc": "^1.4.1"
+      }
+    },
     "node_modules/@vue/language-core": {
       "version": "2.2.12",
       "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.2.12.tgz",
@@ -3397,6 +3422,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/birpc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/bootstrap": {
       "version": "5.3.7",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.7.tgz",
@@ -3691,6 +3725,21 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/copy-anything": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
     },
     "node_modules/core-js-compat": {
       "version": "3.44.0",
@@ -4630,6 +4679,12 @@
         "he": "bin/he"
       }
     },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "license": "MIT"
+    },
     "node_modules/idb": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
@@ -5121,6 +5176,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-what": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
     "node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
@@ -5378,6 +5445,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -5566,6 +5639,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5583,6 +5662,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pinia": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.4.tgz",
+      "integrity": "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^7.7.7"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.5.0",
+        "vue": "^3.5.11"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pinia/node_modules/@vue/devtools-api": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
+      "integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^7.7.9"
       }
     },
     "node_modules/pngjs": {
@@ -5911,6 +6020,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.45.1",
@@ -6258,6 +6373,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -6408,6 +6532,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "bootstrap": "^5.3.7",
     "bootstrap-icons": "^1.13.1",
     "chart.js": "^4.5.1",
+    "pinia": "^3.0.4",
     "primeflex": "^3.3.1",
     "primeicons": "^5.0.0",
     "primevue": "^4.3.2",

--- a/src/components/auth/DashboardLogin.vue
+++ b/src/components/auth/DashboardLogin.vue
@@ -1,0 +1,254 @@
+<!--
+  DashboardLogin — full-page login gate for /dashboard/* routes.
+  Shown when user is not authenticated. Emits 'success' when login completes.
+-->
+<template>
+  <div class="dlogin-shell">
+    <div class="dlogin-card">
+      <!-- Brand -->
+      <div class="dlogin-brand">
+        <i class="bi bi-grid-1x2-fill dlogin-logo"></i>
+        <span class="dlogin-brand-name">Peshkash</span>
+      </div>
+
+      <h4 class="dlogin-title">Welcome back</h4>
+      <p class="dlogin-sub">Sign in with your phone number to access your workspace.</p>
+
+      <!-- Step 1: Phone -->
+      <template v-if="step === 'phone'">
+        <div class="dlogin-field">
+          <label class="dlogin-label">Phone number</label>
+          <div class="dlogin-phone-row">
+            <span class="dlogin-prefix">+91</span>
+            <input
+              v-model="rawPhone"
+              type="tel"
+              class="dlogin-input"
+              placeholder="98765 43210"
+              maxlength="10"
+              inputmode="tel"
+              @keyup.enter="send"
+              autofocus
+            />
+          </div>
+        </div>
+        <div v-if="error" class="dlogin-error">
+          <i class="bi bi-exclamation-circle me-1"></i>{{ error }}
+        </div>
+        <button class="dlogin-btn" :disabled="loading" @click="send">
+          <i v-if="loading" class="bi bi-arrow-clockwise spin me-2"></i>
+          {{ loading ? 'Sending OTP…' : 'Send OTP' }}
+        </button>
+      </template>
+
+      <!-- Step 2: OTP -->
+      <template v-else-if="step === 'otp'">
+        <div class="dlogin-otp-sent">
+          <i class="bi bi-phone-fill me-1 text-success"></i>
+          OTP sent to <strong>+91 {{ rawPhone }}</strong>
+          <button class="dlogin-change-link" @click="changeNumber">Change</button>
+        </div>
+        <div class="dlogin-field">
+          <label class="dlogin-label">6-digit OTP</label>
+          <input
+            v-model="loginState.otp.value"
+            type="text"
+            class="dlogin-otp-input"
+            placeholder="_ _ _ _ _ _"
+            maxlength="6"
+            inputmode="numeric"
+            @keyup.enter="verify"
+            autofocus
+          />
+        </div>
+        <div v-if="error" class="dlogin-error">
+          <i class="bi bi-exclamation-circle me-1"></i>{{ error }}
+        </div>
+        <button class="dlogin-btn" :disabled="loading" @click="verify">
+          <i v-if="loading" class="bi bi-arrow-clockwise spin me-2"></i>
+          {{ loading ? 'Verifying…' : 'Verify & Sign In' }}
+        </button>
+      </template>
+
+      <!-- Step 3: Success (brief, then parent redirects) -->
+      <template v-else-if="step === 'success'">
+        <div class="dlogin-success">
+          <i class="bi bi-check-circle-fill"></i>
+          <p>Signed in successfully!</p>
+          <p class="dlogin-success-sub">Loading your workspace…</p>
+        </div>
+      </template>
+
+      <p class="dlogin-footer">No account needed for customers — just enter your phone and we'll send a code.</p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useOtpLogin } from '../../composables/useOtpLogin';
+import type { Role } from '../../stores/auth';
+
+const emit = defineEmits<{
+  (e: 'success', payload: { role: Role; vendorId: number | null }): void;
+}>();
+
+const loginState = useOtpLogin();
+const { step, phone, otp, loading, error, sendOtp, verifyOtp, reset } = loginState;
+
+const rawPhone = computed({
+  get: () => phone.value.replace(/^\+91/, '').replace(/\s/g, ''),
+  set: v => { phone.value = v; },
+});
+
+async function send() {
+  if (!phone.value.startsWith('+')) {
+    phone.value = '+91' + phone.value.replace(/\D/g, '');
+  }
+  await sendOtp();
+}
+
+async function verify() {
+  const result = await verifyOtp();
+  if (result) {
+    setTimeout(() => emit('success', result), 700);
+  }
+}
+
+function changeNumber() { reset(); }
+</script>
+
+<style scoped>
+.dlogin-shell {
+  min-height: 100dvh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bs-light, #f8f9fa);
+  padding: 1.5rem;
+}
+.dlogin-card {
+  width: 100%;
+  max-width: 400px;
+  background: var(--bs-body-bg, #fff);
+  border-radius: 16px;
+  box-shadow: 0 4px 24px rgba(0,0,0,0.08);
+  padding: 2.5rem 2rem;
+}
+
+/* Brand */
+.dlogin-brand {
+  display: flex; align-items: center; gap: 0.5rem;
+  font-weight: 700; font-size: 1.1rem;
+  margin-bottom: 1.75rem;
+}
+.dlogin-logo { font-size: 1.3rem; color: var(--bs-primary); }
+.dlogin-brand-name { letter-spacing: -0.01em; }
+
+.dlogin-title { font-size: 1.4rem; font-weight: 700; margin-bottom: 0.3rem; }
+.dlogin-sub { font-size: 0.875rem; color: var(--bs-secondary-color, #6c757d); margin-bottom: 1.75rem; }
+
+/* Field */
+.dlogin-field { margin-bottom: 1rem; }
+.dlogin-label { display: block; font-size: 0.78rem; font-weight: 600; margin-bottom: 0.4rem; text-transform: uppercase; letter-spacing: 0.04em; color: var(--bs-body-color); }
+.dlogin-phone-row {
+  display: flex; align-items: center;
+  border: 1.5px solid var(--bs-border-color, #dee2e6);
+  border-radius: 10px; overflow: hidden;
+  background: var(--bs-body-bg, #fff);
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+.dlogin-phone-row:focus-within {
+  border-color: var(--bs-primary);
+  box-shadow: 0 0 0 3px rgba(var(--bs-primary-rgb), 0.15);
+}
+.dlogin-prefix {
+  padding: 0.65rem 0.9rem;
+  background: var(--bs-light, #f8f9fa);
+  border-right: 1.5px solid var(--bs-border-color, #dee2e6);
+  font-size: 0.95rem; font-weight: 600;
+  color: var(--bs-secondary-color, #6c757d);
+  flex-shrink: 0;
+}
+.dlogin-input {
+  flex: 1; border: none; outline: none;
+  padding: 0.65rem 0.9rem;
+  font-size: 1rem; background: transparent;
+  color: var(--bs-body-color);
+}
+.dlogin-otp-input {
+  width: 100%;
+  border: 1.5px solid var(--bs-border-color, #dee2e6);
+  border-radius: 10px;
+  padding: 0.75rem;
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: 0.35em;
+  text-align: center;
+  outline: none;
+  background: var(--bs-body-bg, #fff);
+  color: var(--bs-body-color);
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+.dlogin-otp-input:focus {
+  border-color: var(--bs-primary);
+  box-shadow: 0 0 0 3px rgba(var(--bs-primary-rgb), 0.15);
+}
+
+/* OTP sent note */
+.dlogin-otp-sent {
+  font-size: 0.85rem;
+  color: var(--bs-secondary-color, #6c757d);
+  margin-bottom: 1rem;
+}
+.dlogin-change-link {
+  border: none; background: none;
+  color: var(--bs-primary); font-size: 0.85rem;
+  cursor: pointer; text-decoration: underline;
+  padding: 0; margin-left: 0.5rem;
+}
+
+/* Error */
+.dlogin-error {
+  color: #dc3545;
+  font-size: 0.82rem;
+  margin-bottom: 0.75rem;
+  background: #fff5f5;
+  border: 1px solid #ffd6d6;
+  padding: 0.5rem 0.75rem;
+  border-radius: 8px;
+}
+
+/* Button */
+.dlogin-btn {
+  width: 100%; padding: 0.8rem;
+  border: none; border-radius: 10px;
+  background: var(--bs-primary, #0d6efd);
+  color: #fff; font-size: 1rem; font-weight: 600;
+  cursor: pointer; transition: opacity 0.15s;
+  margin-top: 0.25rem;
+}
+.dlogin-btn:disabled { opacity: 0.65; cursor: not-allowed; }
+.dlogin-btn:not(:disabled):hover { opacity: 0.88; }
+
+/* Success */
+.dlogin-success {
+  text-align: center; padding: 1.5rem 0;
+  color: var(--bs-success, #198754);
+}
+.dlogin-success i { font-size: 3.5rem; display: block; margin-bottom: 0.75rem; }
+.dlogin-success p { font-weight: 600; font-size: 1.15rem; margin-bottom: 0.25rem; }
+.dlogin-success-sub { font-size: 0.85rem; color: var(--bs-secondary-color, #6c757d); font-weight: 400; }
+
+/* Footer note */
+.dlogin-footer {
+  margin-top: 1.5rem; margin-bottom: 0;
+  font-size: 0.75rem;
+  color: var(--bs-secondary-color, #6c757d);
+  text-align: center;
+  line-height: 1.5;
+}
+
+.spin { animation: spin 0.8s linear infinite; }
+@keyframes spin { to { transform: rotate(360deg); } }
+</style>

--- a/src/components/auth/LoginDrawer.vue
+++ b/src/components/auth/LoginDrawer.vue
@@ -1,0 +1,245 @@
+<!--
+  LoginDrawer — lightweight phone→OTP drawer for public vendor/event pages.
+  Used when vendor.requireLogin = true.
+  Emits 'success' with { role, vendorId } on completion.
+-->
+<template>
+  <Teleport to="body">
+    <Transition name="ldrawer-fade">
+      <div v-if="modelValue" class="ldrawer-backdrop" @click.self="$emit('update:modelValue', false)">
+        <Transition name="ldrawer-slide" appear>
+          <div v-if="modelValue" class="ldrawer-panel" role="dialog" aria-label="Sign in">
+
+            <!-- Header -->
+            <div class="ldrawer-header">
+              <div class="ldrawer-brand">
+                <i class="bi bi-grid-1x2-fill ldrawer-logo"></i>
+                <span>Peshkash</span>
+              </div>
+              <button class="ldrawer-close" @click="$emit('update:modelValue', false)">
+                <i class="bi bi-x-lg"></i>
+              </button>
+            </div>
+
+            <!-- Body -->
+            <div class="ldrawer-body">
+              <h5 class="ldrawer-title">Sign in to continue</h5>
+              <p class="ldrawer-sub">Enter your phone number and we'll send a one-time code.</p>
+
+              <!-- Step 1: Phone -->
+              <template v-if="step === 'phone'">
+                <div class="ldrawer-field">
+                  <label class="ldrawer-label">Phone number</label>
+                  <div class="ldrawer-phone-row">
+                    <span class="ldrawer-prefix">+91</span>
+                    <input
+                      v-model="rawPhone"
+                      type="tel"
+                      class="ldrawer-input"
+                      placeholder="98765 43210"
+                      maxlength="10"
+                      inputmode="tel"
+                      @keyup.enter="send"
+                      autofocus
+                    />
+                  </div>
+                </div>
+                <div v-if="error" class="ldrawer-error">{{ error }}</div>
+                <button class="ldrawer-btn-primary" :disabled="loading" @click="send">
+                  <span v-if="loading"><i class="bi bi-arrow-clockwise spin me-1"></i>Sending…</span>
+                  <span v-else>Send OTP</span>
+                </button>
+              </template>
+
+              <!-- Step 2: OTP -->
+              <template v-else-if="step === 'otp'">
+                <p class="ldrawer-sent-msg">
+                  <i class="bi bi-check-circle text-success me-1"></i>
+                  OTP sent to +91 {{ rawPhone }}
+                  <button class="ldrawer-change-link" @click="changeNumber">Change</button>
+                </p>
+                <div class="ldrawer-field">
+                  <label class="ldrawer-label">6-digit OTP</label>
+                  <input
+                    v-model="loginState.otp.value"
+                    type="text"
+                    class="ldrawer-input ldrawer-otp-input"
+                    placeholder="_ _ _ _ _ _"
+                    maxlength="6"
+                    inputmode="numeric"
+                    @keyup.enter="verify"
+                    autofocus
+                  />
+                </div>
+                <div v-if="error" class="ldrawer-error">{{ error }}</div>
+                <button class="ldrawer-btn-primary" :disabled="loading" @click="verify">
+                  <span v-if="loading"><i class="bi bi-arrow-clockwise spin me-1"></i>Verifying…</span>
+                  <span v-else>Verify &amp; Continue</span>
+                </button>
+              </template>
+
+              <!-- Step 3: Success -->
+              <template v-else-if="step === 'success'">
+                <div class="ldrawer-success">
+                  <i class="bi bi-check-circle-fill"></i>
+                  <p>You're in!</p>
+                </div>
+              </template>
+
+              <p class="ldrawer-skip" v-if="allowSkip">
+                <button class="ldrawer-skip-btn" @click="$emit('skip')">Skip for now</button>
+              </p>
+            </div>
+
+          </div>
+        </Transition>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { computed, watch } from 'vue';
+import { useOtpLogin } from '../../composables/useOtpLogin';
+import type { Role } from '../../stores/auth';
+
+const props = defineProps<{
+  modelValue: boolean;
+  allowSkip?: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', val: boolean): void;
+  (e: 'success', payload: { role: Role; vendorId: number | null }): void;
+  (e: 'skip'): void;
+}>();
+
+const loginState = useOtpLogin();
+const { step, phone, otp, loading, error, sendOtp, verifyOtp, reset } = loginState;
+
+// Keep rawPhone in sync with the composable's phone ref (strip +91 prefix)
+const rawPhone = computed({
+  get: () => phone.value.replace(/^\+91/, '').replace(/\s/g, ''),
+  set: v => { phone.value = v; },
+});
+
+async function send() {
+  // Normalise: prepend +91 if not present
+  if (!phone.value.startsWith('+')) {
+    phone.value = '+91' + phone.value.replace(/\D/g, '');
+  }
+  await sendOtp();
+}
+
+async function verify() {
+  const result = await verifyOtp();
+  if (result) {
+    setTimeout(() => {
+      emit('success', result);
+      emit('update:modelValue', false);
+    }, 600);
+  }
+}
+
+function changeNumber() {
+  reset();
+}
+
+// Reset state when drawer closes
+watch(() => props.modelValue, open => {
+  if (!open) reset();
+});
+</script>
+
+<style scoped>
+/* Backdrop */
+.ldrawer-backdrop {
+  position: fixed; inset: 0; z-index: 1070;
+  background: rgba(0,0,0,0.45);
+  backdrop-filter: blur(4px);
+  display: flex; justify-content: flex-end;
+}
+/* Panel */
+.ldrawer-panel {
+  width: 100%; max-width: 380px; height: 100%;
+  background: var(--bs-body-bg, #fff);
+  box-shadow: -4px 0 24px rgba(0,0,0,0.12);
+  display: flex; flex-direction: column;
+}
+@media (max-width: 767px) {
+  .ldrawer-backdrop { align-items: flex-end; justify-content: stretch; }
+  .ldrawer-panel { max-width: 100%; height: auto; max-height: 90dvh; border-radius: 20px 20px 0 0; }
+}
+
+/* Header */
+.ldrawer-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--bs-border-color, #dee2e6);
+}
+.ldrawer-brand {
+  display: flex; align-items: center; gap: 0.5rem;
+  font-weight: 700; font-size: 1rem;
+}
+.ldrawer-logo { font-size: 1.1rem; color: var(--bs-primary); }
+.ldrawer-close {
+  width: 30px; height: 30px; border: none;
+  background: var(--bs-light, #f8f9fa); border-radius: 8px;
+  display: flex; align-items: center; justify-content: center;
+  cursor: pointer; color: var(--bs-secondary-color, #6c757d); font-size: 0.85rem;
+}
+.ldrawer-close:hover { background: var(--bs-secondary-bg, #e9ecef); }
+
+/* Body */
+.ldrawer-body { flex: 1; padding: 1.5rem 1.25rem; overflow-y: auto; }
+.ldrawer-title { font-size: 1.15rem; font-weight: 700; margin-bottom: 0.25rem; }
+.ldrawer-sub { font-size: 0.875rem; color: var(--bs-secondary-color, #6c757d); margin-bottom: 1.5rem; }
+
+/* Field */
+.ldrawer-field { margin-bottom: 1rem; }
+.ldrawer-label { display: block; font-size: 0.8rem; font-weight: 600; margin-bottom: 0.4rem; color: var(--bs-body-color); text-transform: uppercase; letter-spacing: 0.04em; }
+.ldrawer-phone-row { display: flex; align-items: center; border: 1px solid var(--bs-border-color, #dee2e6); border-radius: 10px; overflow: hidden; background: var(--bs-body-bg, #fff); }
+.ldrawer-phone-row:focus-within { border-color: var(--bs-primary); box-shadow: 0 0 0 3px rgba(var(--bs-primary-rgb), 0.15); }
+.ldrawer-prefix { padding: 0.6rem 0.75rem; background: var(--bs-light, #f8f9fa); font-size: 0.9rem; font-weight: 600; color: var(--bs-secondary-color, #6c757d); border-right: 1px solid var(--bs-border-color, #dee2e6); flex-shrink: 0; }
+.ldrawer-input { flex: 1; border: none; outline: none; padding: 0.6rem 0.75rem; font-size: 1rem; background: transparent; color: var(--bs-body-color); }
+.ldrawer-otp-input { letter-spacing: 0.3em; font-size: 1.25rem; font-weight: 700; text-align: center; border: 1px solid var(--bs-border-color, #dee2e6); border-radius: 10px; padding: 0.65rem; width: 100%; }
+.ldrawer-otp-input:focus { border-color: var(--bs-primary); outline: none; box-shadow: 0 0 0 3px rgba(var(--bs-primary-rgb), 0.15); }
+
+/* Sent message */
+.ldrawer-sent-msg { font-size: 0.85rem; color: var(--bs-secondary-color, #6c757d); margin-bottom: 1rem; }
+.ldrawer-change-link { border: none; background: none; color: var(--bs-primary); font-size: 0.85rem; cursor: pointer; text-decoration: underline; padding: 0; margin-left: 0.5rem; }
+
+/* Error */
+.ldrawer-error { color: #dc3545; font-size: 0.82rem; margin-bottom: 0.75rem; }
+
+/* Primary button */
+.ldrawer-btn-primary {
+  width: 100%; padding: 0.75rem; border: none; border-radius: 10px;
+  background: var(--bs-primary, #0d6efd); color: #fff;
+  font-size: 0.95rem; font-weight: 600; cursor: pointer;
+  transition: opacity 0.15s;
+}
+.ldrawer-btn-primary:disabled { opacity: 0.65; cursor: not-allowed; }
+.ldrawer-btn-primary:not(:disabled):hover { opacity: 0.88; }
+
+/* Success */
+.ldrawer-success { text-align: center; padding: 2rem 0; color: var(--bs-success, #198754); }
+.ldrawer-success i { font-size: 3rem; display: block; margin-bottom: 0.75rem; }
+.ldrawer-success p { font-weight: 600; font-size: 1.1rem; margin: 0; }
+
+/* Skip */
+.ldrawer-skip { text-align: center; margin-top: 1.25rem; }
+.ldrawer-skip-btn { border: none; background: none; color: var(--bs-secondary-color, #6c757d); font-size: 0.82rem; cursor: pointer; text-decoration: underline; }
+
+/* Transitions */
+.ldrawer-fade-enter-active, .ldrawer-fade-leave-active { transition: opacity 0.2s; }
+.ldrawer-fade-enter-from, .ldrawer-fade-leave-to { opacity: 0; }
+.ldrawer-slide-enter-active { transition: transform 0.28s cubic-bezier(0.32, 0.72, 0, 1); }
+.ldrawer-slide-leave-active { transition: transform 0.2s ease-in; }
+.ldrawer-slide-enter-from, .ldrawer-slide-leave-to { transform: translateX(100%); }
+@media (max-width: 767px) {
+  .ldrawer-slide-enter-from, .ldrawer-slide-leave-to { transform: translateY(100%); }
+}
+.spin { animation: spin 0.8s linear infinite; }
+@keyframes spin { to { transform: rotate(360deg); } }
+</style>

--- a/src/composables/useOtpLogin.ts
+++ b/src/composables/useOtpLogin.ts
@@ -1,0 +1,67 @@
+/**
+ * useOtpLogin — composable that drives the two-step phone → OTP flow.
+ * Used by both LoginDrawer (public pages) and DashboardLogin (dashboard gate).
+ */
+
+import { ref } from 'vue';
+import axios from 'axios';
+import { API_BASE_URL } from '../config';
+import { useAuthStore, Role } from '../stores/auth';
+
+export type OtpStep = 'phone' | 'otp' | 'success';
+
+export function useOtpLogin() {
+  const authStore = useAuthStore();
+
+  const step    = ref<OtpStep>('phone');
+  const phone   = ref('');
+  const otp     = ref('');
+  const loading = ref(false);
+  const error   = ref('');
+
+  function reset() {
+    step.value  = 'phone';
+    phone.value = '';
+    otp.value   = '';
+    error.value = '';
+  }
+
+  async function sendOtp() {
+    if (!phone.value.trim()) { error.value = 'Enter your phone number.'; return; }
+    loading.value = true;
+    error.value   = '';
+    try {
+      await axios.post(`${API_BASE_URL}/auth/send-otp`, { phone: phone.value.trim() });
+      step.value = 'otp';
+    } catch (e: any) {
+      error.value = e?.response?.data?.error ?? 'Could not send OTP. Try again.';
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  async function verifyOtp(): Promise<{ role: Role; vendorId: number | null } | null> {
+    if (otp.value.length !== 6) { error.value = 'Enter the 6-digit OTP.'; return null; }
+    loading.value = true;
+    error.value   = '';
+    try {
+      const { data } = await axios.post<{
+        token: string; role: Role; vendorId: number | null; phone: string;
+      }>(`${API_BASE_URL}/auth/verify-otp`, {
+        phone: phone.value.trim(),
+        otp:   otp.value.trim(),
+      });
+      authStore.login(data);
+      step.value = 'success';
+      return { role: data.role, vendorId: data.vendorId };
+    } catch (e: any) {
+      error.value = e?.response?.data?.error ?? 'Invalid OTP. Try again.';
+      otp.value   = '';
+      return null;
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  return { step, phone, otp, loading, error, sendOtp, verifyOtp, reset };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import { createApp } from 'vue';
+import { createPinia } from 'pinia';
 import App from './App.vue';
 import './styles.scss';
 import './style.css';
@@ -13,8 +14,7 @@ initGA();
 
 const app = createApp(App);
 
-
+app.use(createPinia());
 app.use(router);
-
 
 app.mount('#app');

--- a/src/pages/AdminDashboard.vue
+++ b/src/pages/AdminDashboard.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="admin-shell" :data-sidebar="sidebarState">
+  <!-- Auth gate: shown when user is not logged in -->
+  <DashboardLogin v-if="!authStore.isLoggedIn" @success="onLoginSuccess" />
+
+  <div v-else class="admin-shell" :data-sidebar="sidebarState">
     <aside class="admin-sidebar" :class="{ 'sidebar--overlay-open': sidebarOverlayOpen }">
       <div class="sidebar-brand">
         <i class="bi bi-grid-1x2-fill sidebar-logo"></i>
@@ -12,7 +15,7 @@
 
       <nav>
         <RouterLink
-          v-for="section in sections"
+          v-for="section in visibleSections"
           :key="section.key"
           :to="dashboardRouteBySection[section.key]"
           class="nav-button"
@@ -25,6 +28,15 @@
         </RouterLink>
       </nav>
       <div class="sidebar-footer">
+        <!-- Auth user info + logout -->
+        <div class="sidebar-user-row">
+          <span class="sidebar-user-phone">{{ authStore.phone }}</span>
+          <span class="sidebar-user-role">{{ authStore.role }}</span>
+        </div>
+        <button class="nav-button sidebar-logout-btn" type="button" title="Sign out" @click="handleLogout">
+          <i class="bi bi-box-arrow-left"></i>
+          <span class="nav-label">Sign out</span>
+        </button>
         <button class="nav-button sidebar-cycle-btn" type="button" :title="sidebarState === 'full' ? 'Compact' : 'Expand'" @click="cycleSidebar">
           <i :class="sidebarState === 'full' ? 'bi bi-layout-sidebar-inset-reverse' : 'bi bi-layout-sidebar-reverse'"></i>
           <span class="nav-label">{{ sidebarState === 'full' ? 'Compact' : 'Expand' }}</span>
@@ -47,8 +59,8 @@
           <button class="refresh-btn" :disabled="loading" title="Refresh" aria-label="Refresh" @click="loadAll">
             <i class="bi bi-arrow-clockwise" :class="{ 'spin': loading }"></i>
           </button>
-          <!-- Workspace gear — home page only, opens modal -->
-          <button v-if="activeSection === 'home'" class="ws-gear-btn" type="button" @click="showWsModal = true" :title="selectedVendor?.displayName || 'Switch workspace'">
+          <!-- Workspace gear — home page only, admin only, opens modal -->
+          <button v-if="activeSection === 'home' && authStore.isAdmin" class="ws-gear-btn" type="button" @click="showWsModal = true" :title="selectedVendor?.displayName || 'Switch workspace'">
             <i class="bi bi-gear-fill"></i>
             <span class="ws-vendor-label">{{ selectedVendor?.displayName || 'Workspace' }}</span>
           </button>
@@ -1445,7 +1457,7 @@
 
   <!-- Mobile hamburger (fixed, outside any sticky container) -->
   <teleport to="body">
-    <button v-if="!sidebarOverlayOpen" class="mobile-hamburger" type="button" aria-label="Open navigation" @click="sidebarOverlayOpen = true">
+    <button v-if="authStore.isLoggedIn && !sidebarOverlayOpen" class="mobile-hamburger" type="button" aria-label="Open navigation" @click="sidebarOverlayOpen = true">
       <i class="bi bi-list"></i>
     </button>
   </teleport>
@@ -1670,7 +1682,11 @@ import PrintStudio from '../components/admin/PrintStudio.vue';
 import AnalyticsSection from '../components/analytics/AnalyticsSection.vue';
 import VendorAnalyticsPanel from '../components/analytics/VendorAnalyticsPanel.vue';
 import ItemAnalyticsPanel from '../components/analytics/ItemAnalyticsPanel.vue';
+import DashboardLogin from '../components/auth/DashboardLogin.vue';
+import { useAuthStore } from '../stores/auth';
 import { API_BASE_URL } from '../config';
+
+const authStore = useAuthStore();
 
 type SectionKey = 'home' | 'vendors' | 'vendorWorkspace' | 'events' | 'eventWorkspace' | 'qrSheet' | 'inventory' | 'analytics' | 'insights' | 'designer' | 'preview' | 'publish' | 'qr' | 'qr-templates' | 'menus' | 'items';
 type Vendor = { id: number; name: string; displayName: string; description?: string; contact: string[]; address?: string; hasContactPage: boolean; logoUrl?: string; createdAt?: string };
@@ -1690,6 +1706,11 @@ const sections = [
   { key: 'qr-templates',  label: 'Print Templates',   icon: 'bi bi-layout-wtf' },
   { key: 'insights',      label: 'Analytics',         icon: 'bi bi-bar-chart-line' },
 ] as const;
+
+// Vendors section is only visible to admins
+const visibleSections = computed(() =>
+  authStore.isAdmin ? sections : sections.filter(s => s.key !== 'vendors')
+);
 
 const route = useRoute();
 const router = useRouter();
@@ -2309,7 +2330,12 @@ async function loadAll() {
     qrMappings.value = qrRes.data;
     previews.menus = previewRes.data.menus.map(normalizePreview);
     previews.items = previewRes.data.items.map(normalizePreview);
-    if (!selectedVendor.value && vendors.value.length) selectedVendorId.value = vendors.value[0].id;
+    // Vendor users are always locked to their own workspace; admins fall back to first vendor
+    if (authStore.isVendor && authStore.vendorId) {
+      selectedVendorId.value = authStore.vendorId;
+    } else if (!selectedVendor.value && vendors.value.length) {
+      selectedVendorId.value = vendors.value[0].id;
+    }
     await loadEventMenuLinks();
     hydrateRouteContext();
   } catch (err) {
@@ -3511,12 +3537,33 @@ watch(activeSection, (section) => {
 });
 
 onMounted(async () => {
+  // Vendor workspace lock: pin to their assigned vendorId
+  if (authStore.isVendor && authStore.vendorId) {
+    selectedVendorId.value = authStore.vendorId;
+  }
   await loadAll();
   selectedMenuIdForItems.value = vendorMenus.value[0]?.id ?? 0;
   selectedEventIdForItems.value = vendorEvents.value[0]?.id ?? 0;
   hydrateRouteContext(); // must run last so URL params always win
   syncItemRows();
 });
+
+// ── Auth handlers ─────────────────────────────────────────────────────────────
+
+function onLoginSuccess(payload: { role: string; vendorId: number | null }) {
+  // If vendor, lock workspace immediately before loadAll runs
+  if (payload.role === 'vendor' && payload.vendorId) {
+    selectedVendorId.value = payload.vendorId;
+  }
+  loadAll();
+}
+
+function handleLogout() {
+  authStore.logout();
+  // Reset to default state
+  selectedVendorId.value = 0;
+  router.push('/dashboard/home');
+}
 
 // ── Delete operations ─────────────────────────────────────────────────────────
 
@@ -3944,6 +3991,37 @@ async function deleteVendorById(id: number, name: string) {
   font-size: 0.8rem;
 }
 .sidebar-cycle-btn:hover { color: rgba(255,255,255,0.7); }
+
+/* Auth / user info in sidebar footer */
+.sidebar-user-row {
+  display: flex;
+  flex-direction: column;
+  padding: 6px 12px 4px;
+  gap: 1px;
+  overflow: hidden;
+}
+.sidebar-user-phone {
+  font-size: 0.78rem;
+  color: rgba(255,255,255,0.65);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.sidebar-user-role {
+  font-size: 0.68rem;
+  color: rgba(255,255,255,0.35);
+  text-transform: capitalize;
+  letter-spacing: 0.04em;
+}
+.sidebar-logout-btn {
+  width: 100%;
+  color: rgba(255,255,255,0.5);
+  font-size: 0.8rem;
+}
+.sidebar-logout-btn:hover { color: #ff7b7b; }
+
+/* Hide user row in icons-only mode (no space) */
+.admin-shell[data-sidebar="icons"] .sidebar-user-row { display: none; }
 
 /* Icons-only state */
 .admin-shell[data-sidebar="icons"] .admin-sidebar { width: 56px; }

--- a/src/router.ts
+++ b/src/router.ts
@@ -135,6 +135,33 @@ export const router = createRouter({
   routes,
 })
 
+// Auth guard — for /dashboard/* routes, check localStorage for a valid session.
+// The DashboardLogin gate in AdminDashboard.vue is the primary UI gate;
+// this guard stores the intended destination so we can redirect after login.
+router.beforeEach((to) => {
+  if (!to.path.startsWith('/dashboard')) return true;
+  const raw = localStorage.getItem('peshkash_auth_v1');
+  if (!raw) return true; // unauthenticated — let AdminDashboard show the login gate
+  try {
+    const auth = JSON.parse(raw);
+    if (Date.now() > auth.expiresAt) {
+      localStorage.removeItem('peshkash_auth_v1');
+      return true; // expired — let gate show
+    }
+    // Vendor users are locked to their own workspace
+    if (auth.role === 'vendor' && auth.vendorId) {
+      const path = to.path;
+      // Allow their own vendor workspace and all sub-routes EXCEPT /dashboard/vendors
+      if (path.startsWith('/dashboard/vendors') && !path.startsWith(`/dashboard/vendors/${auth.vendorId}`)) {
+        return `/dashboard/home`;
+      }
+    }
+    return true;
+  } catch {
+    return true;
+  }
+});
+
 // GA page view on every navigation
 router.afterEach((to) => {
   import('./utils/ga').then(({ gtagPageView }) => gtagPageView(to.fullPath));

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,0 +1,92 @@
+/**
+ * Auth store — persists to localStorage with a 2-day TTL.
+ * Loaded immediately on app boot; all components read from here.
+ */
+
+import { defineStore } from 'pinia';
+import { ref, computed } from 'vue';
+import axios from 'axios';
+import { API_BASE_URL } from '../config';
+
+export type Role = 'admin' | 'vendor' | 'customer';
+
+export interface AuthState {
+  token:     string;
+  phone:     string;
+  role:      Role;
+  vendorId:  number | null;
+  expiresAt: number;   // ms since epoch
+}
+
+const STORAGE_KEY = 'peshkash_auth_v1';
+const TTL_MS      = 2 * 24 * 60 * 60 * 1000; // 48 hours
+
+export const useAuthStore = defineStore('auth', () => {
+  const state = ref<AuthState | null>(null);
+
+  // ── Persistence ────────────────────────────────────────────────────────────
+  function _load() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return;
+      const parsed: AuthState = JSON.parse(raw);
+      if (Date.now() > parsed.expiresAt) {
+        localStorage.removeItem(STORAGE_KEY);
+        return;
+      }
+      state.value = parsed;
+    } catch {
+      localStorage.removeItem(STORAGE_KEY);
+    }
+  }
+
+  function _save(data: Omit<AuthState, 'expiresAt'>) {
+    const full: AuthState = { ...data, expiresAt: Date.now() + TTL_MS };
+    state.value = full;
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(full));
+  }
+
+  // ── Public API ─────────────────────────────────────────────────────────────
+
+  /** Call after successful verifyOtp — sets auth header for all future requests */
+  function login(data: { token: string; phone: string; role: Role; vendorId: number | null }) {
+    _save(data);
+    axios.defaults.headers.common['Authorization'] = `Bearer ${data.token}`;
+  }
+
+  function logout() {
+    state.value = null;
+    localStorage.removeItem(STORAGE_KEY);
+    delete axios.defaults.headers.common['Authorization'];
+  }
+
+  // ── Computed shortcuts ─────────────────────────────────────────────────────
+  const isLoggedIn  = computed(() => !!state.value);
+  const isAdmin     = computed(() => state.value?.role === 'admin');
+  const isVendor    = computed(() => state.value?.role === 'vendor');
+  const isCustomer  = computed(() => state.value?.role === 'customer');
+  const role        = computed(() => state.value?.role ?? null);
+  const vendorId    = computed(() => state.value?.vendorId ?? null);
+  const phone       = computed(() => state.value?.phone ?? null);
+  const token       = computed(() => state.value?.token ?? null);
+
+  // Bootstrap auth header on store init (page reload)
+  _load();
+  if (state.value?.token) {
+    axios.defaults.headers.common['Authorization'] = `Bearer ${state.value.token}`;
+  }
+
+  return {
+    state,
+    login,
+    logout,
+    isLoggedIn,
+    isAdmin,
+    isVendor,
+    isCustomer,
+    role,
+    vendorId,
+    phone,
+    token,
+  };
+});


### PR DESCRIPTION
- Pinia auth store (src/stores/auth.ts): persists token/role/phone/vendorId to localStorage with 48h TTL; bootstraps axios Authorization header on load
- useOtpLogin composable: drives phone->OTP->success flow via /api/auth endpoints
- DashboardLogin component: full-page centered card gate for /dashboard/* routes
- LoginDrawer component: slide-in drawer for public vendor pages (allowSkip prop)
- main.ts: createPinia() registered before router
- router.ts: beforeEach guard blocks vendor users from /dashboard/vendors
- AdminDashboard: shows DashboardLogin gate when not logged in; vendor workspace locked to their vendorId; Vendors nav hidden for non-admins; Sign out button in sidebar footer with phone/role display