### PR TITLE
fix: event-active logic, add image URL field to item drawer

### DIFF
--- a/src/components/DishCard.vue
+++ b/src/components/DishCard.vue
@@ -5,15 +5,15 @@
     role="button"
     tabindex="0"
   >
-    <div class="card-body d-flex align-items-center py-2 px-3">
+    <div class="card-body d-flex align-items-center py-2 px-3 gap-2">
       <!-- Veg/Non-veg Indicator -->
-      <i 
-        v-if="dish.isVeg !== undefined" 
-        class="bi bi-circle-fill me-2" 
+      <i
+        v-if="dish.isVeg !== undefined"
+        class="bi bi-circle-fill"
         :class="dish.isVeg ? 'text-success' : 'text-danger'"
         :aria-label="dish.isVeg ? 'Vegetarian' : 'Non-vegetarian'"
       ></i>
-      
+
       <!-- Dish Name and Description -->
       <div class="flex-grow-1">
         <div class="fw-bold">{{ dish.displayName || dish.name }}</div>
@@ -21,6 +21,15 @@
           {{ truncatedDescription }}
         </small>
       </div>
+
+      <!-- Thumbnail (shown when image URL is set) -->
+      <img
+        v-if="dish.image"
+        :src="dish.image"
+        :alt="dish.displayName || dish.name"
+        class="dish-card-thumb"
+        loading="lazy"
+      />
       
       <!-- Tags/Badges -->
       <span 
@@ -58,6 +67,7 @@ interface Dish {
   description?: string;
   itemType: string;
   isVeg?: boolean;
+  image?: string | null;
   tags?: string[];
   spiceLevel?: number;
 }
@@ -103,5 +113,14 @@ const navigateToDetail = () => {
 
 .text-truncate {
   max-width: 250px;
+}
+
+.dish-card-thumb {
+  flex-shrink: 0;
+  width: 52px;
+  height: 52px;
+  border-radius: 8px;
+  object-fit: cover;
+  border: 1px solid rgba(0, 0, 0, 0.07);
 }
 </style>

--- a/src/components/DishRow.vue
+++ b/src/components/DishRow.vue
@@ -24,7 +24,16 @@
         {{ truncatedDescription }}
       </div>
     </div>
-    
+
+    <!-- Thumbnail (shown when image URL is set) -->
+    <img
+      v-if="dish.image"
+      :src="dish.image"
+      :alt="dish.displayName || dish.name"
+      class="dish-thumb"
+      loading="lazy"
+    />
+
     <!-- Navigate Icon -->
     <i class="bi bi-chevron-right text-muted"></i>
   </div>
@@ -41,6 +50,7 @@ interface Dish {
   description?: string;
   itemType: string;
   isVeg?: boolean;
+  image?: string | null;
 }
 
 interface Props {
@@ -84,6 +94,16 @@ const navigateToDetail = () => {
   cursor: pointer;
   transition: all 0.2s ease;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  gap: 10px;
+}
+
+.dish-thumb {
+  flex-shrink: 0;
+  width: 52px;
+  height: 52px;
+  border-radius: 8px;
+  object-fit: cover;
+  border: 1px solid rgba(189, 148, 90, 0.18);
 }
 
 .dish-row:hover {

--- a/src/pages/AdminDashboard.vue
+++ b/src/pages/AdminDashboard.vue
@@ -1925,7 +1925,7 @@ const selectedAnalyticsItemId = ref<number | null>(null);
 const draggedLibraryItemId = ref<number | null>(null);
 const draggedDesignedItemId = ref<number | null>(null);
 const showItemDrawer = ref(false);
-const itemDraft = reactive({ displayName: '', name: '', type: 'item' as 'item' | 'category', enumType: '', description: '', parentId: null as number | null });
+const itemDraft = reactive({ displayName: '', name: '', type: 'item' as 'item' | 'category', enumType: '', description: '', image: '', parentId: null as number | null });
 const showMenuRenameInline = ref(false);
 const menuRenameValue = ref('');
 const designerMobileTab = ref<'settings' | 'canvas'>('settings');
@@ -3096,7 +3096,7 @@ function uniqueDraftSlug(base: string) {
 
 function openItemDrawer(parentId: number | null) {
   if (!selectedMenuForItems.value) { setError(new Error('Select a working menu first')); return; }
-  Object.assign(itemDraft, { displayName: '', name: '', type: 'item', enumType: '', description: '', parentId: parentId ?? null });
+  Object.assign(itemDraft, { displayName: '', name: '', type: 'item', enumType: '', description: '', image: '', parentId: parentId ?? null });
   showItemDrawer.value = true;
 }
 
@@ -3113,6 +3113,7 @@ function saveItemFromDrawer() {
       type: itemDraft.type,
       enumType: itemDraft.type === 'item' ? itemDraft.enumType : '',
       description: itemDraft.type === 'item' ? itemDraft.description : '',
+      image: itemDraft.type === 'item' ? itemDraft.image : '',
       parentId: itemDraft.parentId ?? undefined,
       isActive: true,
     });

--- a/src/pages/AdminDashboard.vue
+++ b/src/pages/AdminDashboard.vue
@@ -1632,6 +1632,18 @@
               <textarea v-model.trim="itemDraft.description" class="form-control" rows="2" placeholder="Short description, optional"></textarea>
             </label>
             <label>
+              Image URL <small class="muted">(direct link to image, optional)</small>
+              <input
+                v-model.trim="itemDraft.image"
+                class="form-control"
+                type="url"
+                placeholder="https://example.com/photo.jpg"
+              />
+              <div v-if="itemDraft.image" class="image-preview mt-2">
+                <img :src="itemDraft.image" alt="Preview" class="item-img-preview" @error="($event.target as HTMLImageElement).style.display='none'" />
+              </div>
+            </label>
+            <label>
               Tag <small class="muted">(type freely, or tap a suggestion)</small>
               <div class="tag-combobox">
                 <input
@@ -6267,6 +6279,8 @@ td a {
 }
 .item-drawer-fields label { color: #4b3f30; display: flex; flex-direction: column; font-size: 0.82rem; font-weight: 700; gap: 5px; text-transform: uppercase; }
 .item-drawer-fields .required { color: #c84b4b; font-size: 0.7rem; }
+.image-preview { line-height: 0; }
+.item-img-preview { border-radius: 8px; max-height: 120px; max-width: 100%; object-fit: cover; border: 1px solid #e6ddd2; }
 
 .tag-combobox {
   position: relative;

--- a/src/pages/MenuPage.vue
+++ b/src/pages/MenuPage.vue
@@ -151,16 +151,19 @@ const error = ref<string | null>(null)
 const searchQuery = ref('')
 const selectedFilter = ref('All')
 
-// Check if event is currently active
+// Check if event is currently active.
+// Rule: no start/end times = perpetually active (most menus are evergreen).
+// Only show "expired" when BOTH times are set AND the window has passed.
 const isEventActive = computed(() => {
-  if (!menuData.value?.event) return false
-  
+  if (!menuData.value?.event) return true // data not loaded yet — don't flash warning
+
   const now = new Date()
   const startTime = menuData.value.event.startTime ? new Date(menuData.value.event.startTime) : null
   const endTime = menuData.value.event.endTime ? new Date(menuData.value.event.endTime) : null
-  
-  if (!startTime || !endTime) return false
-  
+
+  // No time window configured → always active
+  if (!startTime || !endTime) return true
+
   return now >= startTime && now <= endTime
 })
 


### PR DESCRIPTION
MenuPage.vue: fix isEventActive computed — events with no start/end times are now treated as perpetually active (return true). Previously returned false, showing 'event expired' warning and empty item list for all newly created events that hadn't been given a time window.

AdminDashboard item drawer: add Image URL input field with live preview thumbnail. The image URL is already persisted by the backend (line_item.image column) and returned to the item detail page — the input was simply missing from the UI. Preview img uses @error handler to silently hide broken URLs. CSS: .item-img-preview, .image-preview.